### PR TITLE
ci: pin first release to v0.1.0 and enable Actions PR creation

### DIFF
--- a/.github/scripts/setup-branch-protection.sh
+++ b/.github/scripts/setup-branch-protection.sh
@@ -58,6 +58,14 @@ ensure_remote_branch() {
   git push -u origin "${branch}"
 }
 
+enable_actions_pr_creation() {
+  echo "▶ Habilitando que GitHub Actions abra PRs (necesario para release-please)..."
+  gh api -X PUT "repos/${REPO}/actions/permissions/workflow" \
+    -f default_workflow_permissions=read \
+    -F can_approve_pull_request_reviews=true >/dev/null
+  echo "✓ Permiso de Actions actualizado."
+}
+
 apply_protection() {
   local branch="$1"
 
@@ -97,6 +105,7 @@ JSON
   echo "✓ ${branch} protegida."
 }
 
+enable_actions_pr_creation
 apply_protection main
 apply_protection develop
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ Pasos:
 El job se llama **`Lint, typecheck, test, build`** — ése es el nombre que aparece
 como _required status check_ en la regla de protección de `main`.
 
+> **Nota sobre el primer release:** `release-please-config.json` tiene
+> `release-as: "0.1.0"` para anclar la primera versión. Tras el primer release
+> exitoso (`v0.1.0`), **quitar** ese campo (PR de seguimiento) para que las
+> versiones siguientes se calculen normalmente desde los Conventional Commits.
+> La versión `1.0.0` se reserva para el release final.
+
 ### `release.yml` — tag + GitHub Release
 
 Corre en `push` a `main` (lo que sólo puede ocurrir vía merge de PR, porque la

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,6 +11,7 @@
     ".": {
       "package-name": "miso-4104-angular-practice-assessment",
       "changelog-path": "CHANGELOG.md",
+      "release-as": "0.1.0",
       "release-search-depth": 400,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },


### PR DESCRIPTION
## Summary

Promotes to `main` the release-flow fixes already merged into `develop` (#4):

- **`release-please-config.json`** — pin first release to `v0.1.0` via `release-as`. The default `node` strategy bumped the initial version to `1.0.0`; `1.0.0` is reserved for the final release of the practice assessment.
- **`.github/scripts/setup-branch-protection.sh`** — bootstrap script now also enables *"Allow GitHub Actions to create and approve pull requests"* via the API, so future repos don't hit the error release-please raised on its first run.
- **README** — note about removing `release-as` after `v0.1.0` is published.

## After merge

1. Re-run the failed `release.yml` workflow:
   ```bash
   gh run list --workflow=release.yml --limit=1 --json databaseId -q '.[0].databaseId' \
     | xargs -I {} gh run rerun {}
   ```
2. Release-please updates its existing release PR from `1.0.0` to `v0.1.0`. Merge it.
3. Follow-up PR: remove `release-as` from `release-please-config.json` so subsequent versions come from Conventional Commits.

## Test plan

- [ ] CI workflow passes
- [ ] `Validate PR source branch` passes (head=`develop`, base=`main`)
- [ ] After merge: release-please re-runs and updates the release PR to `v0.1.0`