### PR TITLE
ci: ignore CHANGELOG.md in Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -32,3 +32,6 @@ Thumbs.db
 /public/assets/generated
 *.min.js
 *.min.css
+
+# Managed by release-please (re-written on every release)
+CHANGELOG.md


### PR DESCRIPTION
## Summary

`format:check` failed on `main` after release-please published `v0.1.0` because the auto-generated `CHANGELOG.md` doesn't match Prettier's style. release-please owns and rewrites this file on every release, so forcing Prettier on it would create a recurring CI failure after each release.

Fix: add `CHANGELOG.md` to `.prettierignore`.

## Test plan

- [x] `npm run format:check` passes locally
- [ ] CI workflow passes on this PR
- [ ] Validate PR source branch passes (head=feature/prettier-ignore-changelog, base=develop)