### PR TITLE
ci: ignore CHANGELOG.md in Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -32,3 +32,6 @@ Thumbs.db
 /public/assets/generated
 *.min.js
 *.min.css
+
+# Managed by release-please (re-written on every release)
+CHANGELOG.md


### PR DESCRIPTION
## Summary

Promotes to `main` the Prettier fix already merged into `develop` (#6):

- Add `CHANGELOG.md` to `.prettierignore`. release-please rewrites this file on every release, so letting Prettier touch it creates a recurring CI failure right after each version bump.

## Test plan

- [ ] CI workflow passes
- [ ] `Validate PR source branch` passes (head=`develop`, base=`main`)
- [ ] After merge: `format:check` no longer fails on the next release commit