### PR TITLE
ci: remove release-as pin now that v0.1.0 is published

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,12 +125,6 @@ Pasos:
 El job se llama **`Lint, typecheck, test, build`** — ése es el nombre que aparece
 como _required status check_ en la regla de protección de `main`.
 
-> **Nota sobre el primer release:** `release-please-config.json` tiene
-> `release-as: "0.1.0"` para anclar la primera versión. Tras el primer release
-> exitoso (`v0.1.0`), **quitar** ese campo (PR de seguimiento) para que las
-> versiones siguientes se calculen normalmente desde los Conventional Commits.
-> La versión `1.0.0` se reserva para el release final.
-
 ### `release.yml` — tag + GitHub Release
 
 Corre en `push` a `main` (lo que sólo puede ocurrir vía merge de PR, porque la

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,6 @@
     ".": {
       "package-name": "miso-4104-angular-practice-assessment",
       "changelog-path": "CHANGELOG.md",
-      "release-as": "0.1.0",
       "release-search-depth": 400,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },


### PR DESCRIPTION
## Summary

Promotes to `main` the release-please cleanup already merged into `develop` (#8):

Removes `release-as: "0.1.0"` from `release-please-config.json` so subsequent versions are computed from Conventional Commits (`feat:` → minor, `fix:` → patch, etc.) instead of being pinned to `0.1.0`. With `bump-minor-pre-major: true` already in place, the project stays in the `0.x` range until a deliberate jump to `1.0.0`.

Also removes the temporary README note that referenced the pin.

## Test plan

- [ ] CI workflow passes
- [ ] `Validate PR source branch` passes (head=`develop`, base=`main`)
- [ ] After merge: the next `feat:`/`fix:` commit on `main` triggers a release-please PR with the correct version (not stuck at `0.1.0`)