### PR TITLE
feat(users,repositories): add Users and Repositories modules with HTTP services

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -78,7 +78,7 @@
             "runner": "vitest",
             "watch": false,
             "reporters": ["default"],
-            "include": ["src/**/*.spec.ts"],
+            "include": ["../test/**/*.spec.ts"],
             "setupFiles": ["src/setup-tests.ts"],
             "providersFile": "src/test-providers.ts",
             "coverage": false

--- a/src/app/features/repositories/index.ts
+++ b/src/app/features/repositories/index.ts
@@ -1,0 +1,3 @@
+export { Repository } from './repository';
+export type { RepositoryDto, RepositoryFilters } from './repository';
+export { Repositories } from './repositories';

--- a/src/app/features/repositories/repositories.ts
+++ b/src/app/features/repositories/repositories.ts
@@ -1,0 +1,46 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { type Observable, map, shareReplay } from 'rxjs';
+
+import { environment } from '@env/environment';
+import { Repository, type RepositoryDto, type RepositoryFilters } from './repository';
+
+/**
+ * Servicio HTTP para Repositorios.
+ *
+ * Hace una sola llamada a `environment.apis.repositories` y comparte la
+ * respuesta entre todos los suscriptores con `shareReplay`. Las consultas
+ * de búsqueda son in-memory sobre el último snapshot.
+ */
+@Injectable({ providedIn: 'root' })
+export class Repositories {
+  private readonly http = inject(HttpClient);
+  private readonly url = environment.apis.repositories;
+
+  private readonly repos$: Observable<readonly Repository[]> = this.http
+    .get<readonly RepositoryDto[]>(this.url)
+    .pipe(
+      map((dtos) => dtos.map((dto) => new Repository(dto))),
+      shareReplay({ bufferSize: 1, refCount: false }),
+    );
+
+  list(): Observable<readonly Repository[]> {
+    return this.repos$;
+  }
+
+  findById(id: number): Observable<Repository | undefined> {
+    return this.repos$.pipe(map((repos) => repos.find((repo) => repo.id === id)));
+  }
+
+  findByOwnerId(ownerId: number): Observable<readonly Repository[]> {
+    return this.repos$.pipe(map((repos) => repos.filter((repo) => repo.isOwnedBy(ownerId))));
+  }
+
+  /**
+   * Devuelve los repos que cumplen TODOS los filtros indicados (AND).
+   * `search({})` ≡ `list()`.
+   */
+  search(filters: RepositoryFilters): Observable<readonly Repository[]> {
+    return this.repos$.pipe(map((repos) => repos.filter((repo) => repo.matches(filters))));
+  }
+}

--- a/src/app/features/repositories/repository.ts
+++ b/src/app/features/repositories/repository.ts
@@ -1,0 +1,98 @@
+/** Forma cruda del JSON externo (DTO). */
+export interface RepositoryDto {
+  readonly id: number;
+  readonly name: string;
+  readonly description: string;
+  readonly language: string;
+  readonly stars: number;
+  readonly createdAt: string;
+  readonly ownerId: number;
+}
+
+export interface RepositoryFilters {
+  /** Coincidencia exacta de lenguaje (case-insensitive). */
+  readonly language?: string;
+  /** Filtra por dueño (User.id). */
+  readonly ownerId?: number;
+  /** Mínimo inclusivo de estrellas. */
+  readonly minStars?: number;
+  /** Máximo inclusivo de estrellas. */
+  readonly maxStars?: number;
+  /** Coincidencia parcial (case-insensitive) sobre `name` o `description`. */
+  readonly query?: string;
+  /** Fecha ISO (`YYYY-MM-DD`); incluye repos creados en esa fecha o después. */
+  readonly createdAfter?: string;
+  /** Fecha ISO (`YYYY-MM-DD`); incluye repos creados en esa fecha o antes. */
+  readonly createdBefore?: string;
+}
+
+/**
+ * Entidad de dominio Repositorio.
+ *
+ * Inmutable; las propiedades son `readonly`. Los métodos exponen el
+ * comportamiento natural del dominio (popularidad, comparación de fechas,
+ * coincidencia con filtros).
+ */
+export class Repository {
+  readonly id: number;
+  readonly name: string;
+  readonly description: string;
+  readonly language: string;
+  readonly stars: number;
+  readonly createdAt: string;
+  readonly ownerId: number;
+
+  constructor(dto: RepositoryDto) {
+    this.id = dto.id;
+    this.name = dto.name;
+    this.description = dto.description;
+    this.language = dto.language;
+    this.stars = dto.stars;
+    this.createdAt = dto.createdAt;
+    this.ownerId = dto.ownerId;
+  }
+
+  /** `Date` parseado a partir del campo `createdAt` ISO. */
+  get createdAtDate(): Date {
+    return new Date(this.createdAt);
+  }
+
+  isOwnedBy(userId: number): boolean {
+    return this.ownerId === userId;
+  }
+
+  isPopular(threshold = 100): boolean {
+    return this.stars >= threshold;
+  }
+
+  matches(filters: RepositoryFilters): boolean {
+    if (
+      filters.language !== undefined &&
+      this.language.toLowerCase() !== filters.language.toLowerCase()
+    ) {
+      return false;
+    }
+    if (filters.ownerId !== undefined && this.ownerId !== filters.ownerId) {
+      return false;
+    }
+    if (filters.minStars !== undefined && this.stars < filters.minStars) {
+      return false;
+    }
+    if (filters.maxStars !== undefined && this.stars > filters.maxStars) {
+      return false;
+    }
+    if (filters.query !== undefined) {
+      const q = filters.query.toLowerCase();
+      if (!this.name.toLowerCase().includes(q) && !this.description.toLowerCase().includes(q)) {
+        return false;
+      }
+    }
+    if (filters.createdAfter !== undefined && this.createdAt < filters.createdAfter) {
+      return false;
+    }
+    if (filters.createdBefore !== undefined && this.createdAt > filters.createdBefore) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/app/features/users/index.ts
+++ b/src/app/features/users/index.ts
@@ -1,0 +1,3 @@
+export { User } from './user';
+export type { UserDto, UserFilters, Role } from './user';
+export { Users } from './users';

--- a/src/app/features/users/user.ts
+++ b/src/app/features/users/user.ts
@@ -1,0 +1,87 @@
+export type Role = 'admin' | 'developer' | 'designer';
+
+/** Forma cruda del JSON externo (DTO). */
+export interface UserDto {
+  readonly id: number;
+  readonly username: string;
+  readonly name: string;
+  readonly email: string;
+  readonly avatarUrl: string;
+  readonly role: Role;
+  readonly location: string;
+  readonly repoIds: readonly number[];
+}
+
+export interface UserFilters {
+  /** Coincidencia exacta de rol. */
+  readonly role?: Role;
+  /** Coincidencia parcial (case-insensitive) sobre `location`. */
+  readonly location?: string;
+  /** Coincidencia parcial (case-insensitive) sobre `name` o `username`. */
+  readonly query?: string;
+  /** `true` → solo usuarios con al menos un repo; `false` → solo sin repos. */
+  readonly hasRepos?: boolean;
+}
+
+/**
+ * Entidad de dominio Usuario.
+ *
+ * Inmutable; las propiedades son `readonly`. Los métodos exponen el
+ * comportamiento natural del dominio (¿tiene repos?, ¿coincide con un filtro?).
+ */
+export class User {
+  readonly id: number;
+  readonly username: string;
+  readonly name: string;
+  readonly email: string;
+  readonly avatarUrl: string;
+  readonly role: Role;
+  readonly location: string;
+  readonly repoIds: readonly number[];
+
+  constructor(dto: UserDto) {
+    this.id = dto.id;
+    this.username = dto.username;
+    this.name = dto.name;
+    this.email = dto.email;
+    this.avatarUrl = dto.avatarUrl;
+    this.role = dto.role;
+    this.location = dto.location;
+    this.repoIds = [...dto.repoIds];
+  }
+
+  /** Útil para `*ngFor` y consumidores que usan `id` como display name. */
+  get displayName(): string {
+    return this.name;
+  }
+
+  hasRepos(): boolean {
+    return this.repoIds.length > 0;
+  }
+
+  ownsRepo(repoId: number): boolean {
+    return this.repoIds.includes(repoId);
+  }
+
+  matches(filters: UserFilters): boolean {
+    if (filters.role !== undefined && this.role !== filters.role) {
+      return false;
+    }
+    if (
+      filters.location !== undefined &&
+      !this.location.toLowerCase().includes(filters.location.toLowerCase())
+    ) {
+      return false;
+    }
+    if (filters.query !== undefined) {
+      const q = filters.query.toLowerCase();
+      if (!this.name.toLowerCase().includes(q) && !this.username.toLowerCase().includes(q)) {
+        return false;
+      }
+    }
+    if (filters.hasRepos !== undefined && this.hasRepos() !== filters.hasRepos) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/app/features/users/users.ts
+++ b/src/app/features/users/users.ts
@@ -1,0 +1,42 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { type Observable, map, shareReplay } from 'rxjs';
+
+import { environment } from '@env/environment';
+import { User, type UserDto, type UserFilters } from './user';
+
+/**
+ * Servicio HTTP para Usuarios.
+ *
+ * Hace una sola llamada a `environment.apis.users` y comparte la respuesta
+ * entre todos los suscriptores con `shareReplay`. Las consultas de búsqueda
+ * son in-memory sobre el último snapshot.
+ */
+@Injectable({ providedIn: 'root' })
+export class Users {
+  private readonly http = inject(HttpClient);
+  private readonly url = environment.apis.users;
+
+  private readonly users$: Observable<readonly User[]> = this.http
+    .get<readonly UserDto[]>(this.url)
+    .pipe(
+      map((dtos) => dtos.map((dto) => new User(dto))),
+      shareReplay({ bufferSize: 1, refCount: false }),
+    );
+
+  list(): Observable<readonly User[]> {
+    return this.users$;
+  }
+
+  findById(id: number): Observable<User | undefined> {
+    return this.users$.pipe(map((users) => users.find((user) => user.id === id)));
+  }
+
+  /**
+   * Devuelve los usuarios que cumplen TODOS los filtros indicados (AND).
+   * `search({})` ≡ `list()`.
+   */
+  search(filters: UserFilters): Observable<readonly User[]> {
+    return this.users$.pipe(map((users) => users.filter((user) => user.matches(filters))));
+  }
+}

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -1,3 +1,9 @@
 export const environment = {
   production: false,
+  apis: {
+    users:
+      'https://gist.githubusercontent.com/caev03/628509e0b3fe41dd44f6a2ab09d81ef9/raw/f847eafbecca47287ff0faec4de1329b874f5711/users.json',
+    repositories:
+      'https://gist.githubusercontent.com/caev03/628509e0b3fe41dd44f6a2ab09d81ef9/raw/f847eafbecca47287ff0faec4de1329b874f5711/repositories.json',
+  },
 } as const;

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,3 +1,9 @@
 export const environment = {
   production: true,
+  apis: {
+    users:
+      'https://gist.githubusercontent.com/caev03/628509e0b3fe41dd44f6a2ab09d81ef9/raw/f847eafbecca47287ff0faec4de1329b874f5711/users.json',
+    repositories:
+      'https://gist.githubusercontent.com/caev03/628509e0b3fe41dd44f6a2ab09d81ef9/raw/f847eafbecca47287ff0faec4de1329b874f5711/repositories.json',
+  },
 } as const;

--- a/test/app/app.spec.ts
+++ b/test/app/app.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
-import { App } from './app';
+import { App } from '@app/app';
 
 describe('App', () => {
   beforeEach(async () => {

--- a/test/app/features/home/home.spec.ts
+++ b/test/app/features/home/home.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { Home } from './home';
+import { Home } from '@features/home/home';
 
 describe('Home', () => {
   beforeEach(async () => {

--- a/test/app/features/repositories/repositories.spec.ts
+++ b/test/app/features/repositories/repositories.spec.ts
@@ -1,0 +1,128 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { firstValueFrom } from 'rxjs';
+
+import { environment } from '@env/environment';
+import { Repositories, type RepositoryDto } from '@features/repositories';
+
+const FIXTURE: RepositoryDto[] = [
+  {
+    id: 101,
+    name: 'repo-101',
+    description: 'Angular project',
+    language: 'TypeScript',
+    stars: 50,
+    createdAt: '2025-01-01',
+    ownerId: 1,
+  },
+  {
+    id: 102,
+    name: 'repo-102',
+    description: 'NestJS API',
+    language: 'TypeScript',
+    stars: 40,
+    createdAt: '2025-01-05',
+    ownerId: 1,
+  },
+  {
+    id: 121,
+    name: 'repo-121',
+    description: 'AI model',
+    language: 'Python',
+    stars: 120,
+    createdAt: '2025-03-22',
+    ownerId: 15,
+  },
+];
+
+describe('Repositories (service)', () => {
+  let service: Repositories;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(Repositories);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  function flushFixture(): void {
+    const req = httpMock.expectOne(environment.apis.repositories);
+    expect(req.request.method).toBe('GET');
+    req.flush(FIXTURE);
+  }
+
+  it('should fetch repositories via HTTP and return Repository instances', async () => {
+    const promise = firstValueFrom(service.list());
+    flushFixture();
+    const repos = await promise;
+
+    expect(repos.length).toBe(3);
+    expect(repos[0]?.constructor.name).toBe('Repository');
+    expect(repos[0]?.id).toBe(101);
+  });
+
+  it('should share the HTTP response across subscribers (single GET)', async () => {
+    const p1 = firstValueFrom(service.list());
+    const p2 = firstValueFrom(service.findByOwnerId(1));
+    flushFixture();
+
+    expect((await p1).length).toBe(3);
+    expect((await p2).length).toBe(2);
+  });
+
+  it('should find a repository by id', async () => {
+    const promise = firstValueFrom(service.findById(121));
+    flushFixture();
+    expect((await promise)?.name).toBe('repo-121');
+  });
+
+  it('should return repositories owned by a user', async () => {
+    const promise = firstValueFrom(service.findByOwnerId(1));
+    flushFixture();
+    const repos = await promise;
+    expect(repos.map((r) => r.id).sort()).toEqual([101, 102]);
+  });
+
+  it('should filter by language (case-insensitive)', async () => {
+    const promise = firstValueFrom(service.search({ language: 'typescript' }));
+    flushFixture();
+    const repos = await promise;
+    expect(repos.every((r) => r.language === 'TypeScript')).toBe(true);
+    expect(repos.length).toBe(2);
+  });
+
+  it('should filter by stars range', async () => {
+    const promise = firstValueFrom(service.search({ minStars: 50, maxStars: 100 }));
+    flushFixture();
+    const repos = await promise;
+    expect(repos.map((r) => r.id).sort()).toEqual([101]);
+  });
+
+  it('should filter by query against name OR description', async () => {
+    const promise = firstValueFrom(service.search({ query: 'nestjs' }));
+    flushFixture();
+    const repos = await promise;
+    expect(repos.map((r) => r.id)).toEqual([102]);
+  });
+
+  it('should filter by createdAfter (inclusive)', async () => {
+    const promise = firstValueFrom(service.search({ createdAfter: '2025-03-01' }));
+    flushFixture();
+    const repos = await promise;
+    expect(repos.map((r) => r.id)).toEqual([121]);
+  });
+
+  it('should AND multiple filters', async () => {
+    const promise = firstValueFrom(service.search({ language: 'TypeScript', minStars: 45 }));
+    flushFixture();
+    const repos = await promise;
+    expect(repos.map((r) => r.id)).toEqual([101]);
+  });
+});

--- a/test/app/features/users/users.spec.ts
+++ b/test/app/features/users/users.spec.ts
@@ -1,0 +1,133 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { firstValueFrom } from 'rxjs';
+
+import { environment } from '@env/environment';
+import { Users, type UserDto } from '@features/users';
+
+const FIXTURE: UserDto[] = [
+  {
+    id: 1,
+    username: 'user1',
+    name: 'User One',
+    email: 'user1@mail.com',
+    avatarUrl: 'https://i.pravatar.cc/150?img=1',
+    role: 'admin',
+    location: 'Bogotá',
+    repoIds: [101, 102],
+  },
+  {
+    id: 2,
+    username: 'user2',
+    name: 'User Two',
+    email: 'user2@mail.com',
+    avatarUrl: 'https://i.pravatar.cc/150?img=2',
+    role: 'developer',
+    location: 'Medellín',
+    repoIds: [103],
+  },
+  {
+    id: 22,
+    username: 'user22',
+    name: 'User Twenty Two',
+    email: 'user22@mail.com',
+    avatarUrl: 'https://i.pravatar.cc/150?img=22',
+    role: 'developer',
+    location: 'Florencia',
+    repoIds: [],
+  },
+];
+
+describe('Users (service)', () => {
+  let service: Users;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(Users);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  function flushFixture(): void {
+    const req = httpMock.expectOne(environment.apis.users);
+    expect(req.request.method).toBe('GET');
+    req.flush(FIXTURE);
+  }
+
+  it('should fetch users via HTTP and return User instances', async () => {
+    const promise = firstValueFrom(service.list());
+    flushFixture();
+    const users = await promise;
+
+    expect(users.length).toBe(3);
+    expect(users[0]?.id).toBe(1);
+    expect(users[0]?.constructor.name).toBe('User');
+  });
+
+  it('should share the HTTP response across subscribers (single GET)', async () => {
+    const p1 = firstValueFrom(service.list());
+    const p2 = firstValueFrom(service.findById(2));
+    flushFixture();
+
+    const users = await p1;
+    const user = await p2;
+    expect(users.length).toBe(3);
+    expect(user?.username).toBe('user2');
+    // verify() at afterEach garantiza que solo hubo 1 GET.
+  });
+
+  it('should find a user by id', async () => {
+    const promise = firstValueFrom(service.findById(2));
+    flushFixture();
+    const user = await promise;
+    expect(user?.username).toBe('user2');
+  });
+
+  it('should return undefined for unknown id', async () => {
+    const promise = firstValueFrom(service.findById(9999));
+    flushFixture();
+    expect(await promise).toBeUndefined();
+  });
+
+  it('should filter by role', async () => {
+    const promise = firstValueFrom(service.search({ role: 'admin' }));
+    flushFixture();
+    const users = await promise;
+    expect(users.map((u) => u.id)).toEqual([1]);
+  });
+
+  it('should filter by location (case-insensitive)', async () => {
+    const promise = firstValueFrom(service.search({ location: 'BOG' }));
+    flushFixture();
+    const users = await promise;
+    expect(users.map((u) => u.location)).toEqual(['Bogotá']);
+  });
+
+  it('should filter by query against name OR username', async () => {
+    const promise = firstValueFrom(service.search({ query: 'twenty two' }));
+    flushFixture();
+    const users = await promise;
+    expect(users.map((u) => u.id)).toEqual([22]);
+  });
+
+  it('should filter by hasRepos', async () => {
+    const promise = firstValueFrom(service.search({ hasRepos: false }));
+    flushFixture();
+    const users = await promise;
+    expect(users.map((u) => u.id)).toEqual([22]);
+  });
+
+  it('should AND multiple filters', async () => {
+    const promise = firstValueFrom(service.search({ role: 'developer', hasRepos: true }));
+    flushFixture();
+    const users = await promise;
+    expect(users.map((u) => u.id)).toEqual([2]);
+  });
+});

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -10,5 +10,5 @@
     "types": ["node"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.spec.ts", "src/setup-tests.ts", "src/test-providers.ts"]
+  "exclude": ["src/setup-tests.ts", "src/test-providers.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,7 +33,8 @@
       "@shared/*": ["./src/app/shared/*"],
       "@features/*": ["./src/app/features/*"],
       "@layouts/*": ["./src/app/layouts/*"],
-      "@env/*": ["./src/environments/*"]
+      "@env/*": ["./src/environments/*"],
+      "@test/*": ["./test/*"]
     }
   },
   "angularCompilerOptions": {

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -5,10 +5,9 @@
   "compilerOptions": {
     "composite": true,
     "outDir": "./out-tsc/spec",
-    "rootDir": "./src",
     "tsBuildInfoFile": "./out-tsc/spec/.tsbuildinfo",
     "types": ["vitest/globals", "node"]
   },
-  "include": ["src/**/*.d.ts", "src/**/*.spec.ts", "src/setup-tests.ts", "src/test-providers.ts"],
+  "include": ["test/**/*.ts", "src/setup-tests.ts", "src/test-providers.ts"],
   "references": [{ "path": "./tsconfig.app.json" }]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,8 +4,8 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    include: ['src/**/*.spec.ts'],
-    setupFiles: ['src/setup-tests.ts'],
+    include: ['test/**/*.spec.ts'],
+    setupFiles: ['test/setup-tests.ts'],
     css: true,
     restoreMocks: true,
     clearMocks: true,
@@ -19,14 +19,12 @@ export default defineConfig({
       reportsDirectory: 'coverage',
       include: ['src/app/**/*.ts'],
       exclude: [
-        'src/**/*.spec.ts',
         'src/**/*.d.ts',
         'src/main.ts',
         'src/main.server.ts',
         'src/server.ts',
-        'src/setup-tests.ts',
-        'src/test-providers.ts',
         'src/environments/**',
+        'test/**',
       ],
       thresholds: {
         statements: 80,
@@ -44,6 +42,7 @@ export default defineConfig({
       '@features': new URL('./src/app/features/', import.meta.url).pathname,
       '@layouts': new URL('./src/app/layouts/', import.meta.url).pathname,
       '@env': new URL('./src/environments/', import.meta.url).pathname,
+      '@test': new URL('./test/', import.meta.url).pathname,
     },
   },
 });


### PR DESCRIPTION
## Summary

Adds two domain feature modules under `src/app/features/` and reorganizes the test tree into a dedicated `test/` directory at the project root that mirrors `src/`.

### Module: Users (`src/app/features/users/`)
- **`user.ts`** — `User` class (immutable, `readonly` fields). Behaviour: `displayName`, `hasRepos()`, `ownsRepo(repoId)`, `matches(filters)`. Co-locates `Role`, `UserDto`, `UserFilters`.
- **`users.ts`** — HTTP service (`@Injectable({ providedIn: 'root' })`). Single GET to `environment.apis.users` con `shareReplay` para que múltiples suscriptores compartan la misma petición. API: `list()`, `findById(id)`, `search({ role?, location?, query?, hasRepos? })`.
- **`index.ts`** — barrel.

### Module: Repositories (`src/app/features/repositories/`)
- **`repository.ts`** — `Repository` class con `readonly` fields. Behaviour: `createdAtDate`, `isOwnedBy(userId)`, `isPopular(threshold=100)`, `matches(filters)`. Co-locates `RepositoryDto`, `RepositoryFilters`.
- **`repositories.ts`** — HTTP service equivalente. API: `list()`, `findById(id)`, `findByOwnerId(ownerId)`, `search({ language?, ownerId?, minStars?, maxStars?, query?, createdAfter?, createdBefore? })`.
- **`index.ts`** — barrel.

### Environment
- `src/environments/environment.ts` y `environment.development.ts` exponen `apis.users` y `apis.repositories` (las URLs de los gists de Camilo). Cambiar la URL = un solo lugar.

### Estructura de tests (espejo de src/)
```
test/
├── app/
│   ├── app.spec.ts                              ↔ src/app/app.ts
│   └── features/
│       ├── home/home.spec.ts                    ↔ src/app/features/home/home.ts
│       ├── users/users.spec.ts                  ↔ src/app/features/users/users.ts
│       └── repositories/repositories.spec.ts    ↔ src/app/features/repositories/repositories.ts
```

- Specs importan vía aliases (`@app/*`, `@features/*`, `@env/*`) — sobreviven el cambio de árbol sin relatives rotos.
- `setup-tests.ts` y `test-providers.ts` quedan en `src/` (son **infra del runner**, no specs; Angular resuelve `setupFiles`/`providersFile` desde `sourceRoot=src`).
- **`angular.json`** — `include: ["../test/**/*.spec.ts"]` (escapando de `sourceRoot=src` con `../`).
- **`vitest.config.ts`** — `include: ["test/**/*.spec.ts"]`; `coverage.exclude` añade `test/**`; alias `@test/*` añadido.
- **`tsconfig.spec.json`** — `include` ahora cubre `test/**/*.ts` + las dos entradas de infra en `src/`.
- **`tsconfig.app.json`** — `exclude` explícito para `setup-tests.ts` y `test-providers.ts`.
- **`tsconfig.json`** — alias `@test/*` añadido.

## Test plan

- [x] `npm run format:check` passes
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (22 tests: 2 app + 2 home + 9 users + 9 repositories)
- [x] `npm run build` passes
- [ ] CI workflow passes
- [ ] `Validate PR source branch` passes
- [ ] After promotion to `main`: release-please bumps `0.1.0 → 0.2.0` (commit prefix `feat:`)