### PR TITLE
fix(footer,layout): center footer on mobile and make main area fill the viewport

### DIFF
--- a/src/app/layouts/main/main-layout.css
+++ b/src/app/layouts/main/main-layout.css
@@ -1,20 +1,24 @@
 :host {
+  /* Altura del navbar (responsive). Reasignada en media queries para que
+     `.layout__main` la consuma vía calc() y siempre llene el viewport visible. */
+  --layout-navbar-h: var(--navbar-height-base, 4rem);
+
   display: flex;
   flex-direction: column;
   min-height: 100dvh;
   /* Reservar el espacio del navbar fijo */
-  padding-top: var(--navbar-height-base, 4rem);
+  padding-top: var(--layout-navbar-h);
 }
 
 @media (max-width: 1024px) {
   :host {
-    padding-top: 3.75rem;
+    --layout-navbar-h: 3.75rem;
   }
 }
 
 @media (max-width: 768px) {
   :host {
-    padding-top: 3.5rem;
+    --layout-navbar-h: 3.5rem;
   }
 }
 
@@ -24,4 +28,8 @@
   max-width: var(--container-max, 64rem);
   padding: 2rem clamp(1rem, 3vw, 1.5rem);
   flex: 1;
+  /* Llena el viewport visible (debajo del navbar). El footer queda abajo,
+     visible solo al hacer scroll. `dvh` ajusta la altura cuando el chrome
+     del navegador móvil aparece/desaparece. */
+  min-height: calc(100dvh - var(--layout-navbar-h));
 }

--- a/src/app/shared/ui/footer/footer.css
+++ b/src/app/shared/ui/footer/footer.css
@@ -243,14 +243,54 @@
 }
 
 @media (max-width: 768px) {
+  /* En móvil todo se apila y se centra horizontal + verticalmente */
   .footer__inner {
     grid-template-columns: 1fr;
     gap: 2rem;
+    justify-items: center;
+    text-align: center;
+  }
+
+  .footer__brand {
+    align-items: center;
+    max-width: 36ch;
+  }
+
+  /* El logo tiene `align-self: flex-start` por default → forzamos center en móvil */
+  .footer__logo-link {
+    align-self: center;
+  }
+
+  .footer__tagline {
+    max-width: 36ch;
+  }
+
+  .footer__col {
+    align-items: center;
+  }
+
+  /* Con texto centrado, el shift horizontal del hover queda raro → cambio a vertical */
+  .footer__link:hover {
+    transform: translateY(-2px);
+  }
+
+  .footer__link::after {
+    left: 50%;
+    right: auto;
+    width: 100%;
+    transform: translateX(-50%) scaleX(0);
+    transform-origin: center;
+  }
+
+  .footer__link:hover::after {
+    transform: translateX(-50%) scaleX(1);
   }
 
   .footer__bottom {
     flex-direction: column;
-    align-items: flex-start;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
     gap: 0.25rem;
   }
 }


### PR DESCRIPTION
## Summary

Two related polish tweaks in `src/app/shared/ui/footer/footer.css` and `src/app/layouts/main/main-layout.css`:

### Footer centering on mobile
- En el breakpoint `≤ 768px` el footer se apila pero antes quedaba alineado a la izquierda.
- Ahora todo se centra **horizontal y verticalmente**: `.footer__inner` (`justify-items + text-align`), `.footer__brand` y `.footer__col` (`align-items: center`), banda `.footer__bottom` (`align-items + justify-content + text-align: center`).
- El logo necesitó override explícito: el desktop fija `align-self: flex-start` en `.footer__logo-link` para evitar el stretch del flex; en móvil se cambia a `align-self: center`.
- La animación hover de los links (que en desktop hace `translateX(3px)` con underline anclado a la izquierda) se cambia en móvil a `translateY(-2px)` con underline anclado al centro (`left: 50%; scaleX(0 → 1)`) para que el efecto encaje con el texto centrado.

### Main area dynamic height
- `.layout__main` ahora llena el viewport visible debajo del navbar; el footer solo aparece al hacer scroll.
- Patrón:
  ```css
  :host {
    --layout-navbar-h: 4rem;
  }
  @media (max-width:1024px) { :host { --layout-navbar-h: 3.75rem } }
  @media (max-width:768px)  { :host { --layout-navbar-h: 3.5rem } }
  .layout__main {
    min-height: calc(100dvh - var(--layout-navbar-h));
  }
  ```
- `dvh` (dynamic viewport height) en lugar de `vh` evita el scroll fantasma cuando el chrome del navegador móvil colapsa/expande.
- La variable `--layout-navbar-h` se redefine por breakpoint, así el `calc()` siempre resta la altura real del navbar en cada tamaño (evita el "espacio fantasma" de hardcodear un valor).

## Test plan

- [x] `npm run format:check` passes
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] Verificado vía dev container que el SSR sirve los nuevos breakpoints
- [ ] CI workflow passes
- [ ] `Validate PR source branch` passes