### PR TITLE
feat(deploy): add GitHub Pages deployment via prerender + gh-pages branch

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,53 @@
+name: Deploy
+
+on:
+  # Cada merge a main dispara el deploy
+  push:
+    branches: [main]
+  # Permite re-deploy manual desde la UI
+  workflow_dispatch:
+
+# Solo un deploy a la vez por rama; cancela los pendientes que estén corriendo
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write # necesario para que peaceiris/actions-gh-pages haga push a la rama gh-pages
+
+jobs:
+  build-and-deploy:
+    name: Build & deploy to gh-pages
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.18.0
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Build static site (prerender)
+        run: npm run build:gh-pages
+
+      - name: Deploy to gh-pages branch
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist/MISO-4104-ANGULAR-PRACTICE-ASSESSMENT/browser
+          publish_branch: gh-pages
+          # No fork de Jekyll; .nojekyll se crea automáticamente
+          enable_jekyll: false
+          # force_orphan: cada deploy reescribe el branch desde cero (no historia gigante)
+          force_orphan: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: 'deploy: ${{ github.sha }}'

--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ src/
   `Prerender` cuando la ruta sea estática).
 - Los assets se sirven desde `/browser` con `Cache-Control: max-age=1y`.
 
-## CI / Release
+## CI / Release / Deploy
 
-Dos workflows en `.github/workflows/`:
+Tres workflows en `.github/workflows/`:
 
 ### `ci.yml` — calidad
 
@@ -139,6 +139,35 @@ gestionar versionado por **Conventional Commits**:
 2. Al mergear esa PR de release, crea automáticamente:
    - Un tag git (`v0.1.0`, `v0.2.0`, ...).
    - Un GitHub Release con título y notas extraídas del CHANGELOG.
+
+### `deploy-pages.yml` — deploy estático a GitHub Pages
+
+Corre en `push` a `main` (después de cada merge) y al disparar manualmente.
+Pre-renderiza las 3 rutas (Home, Usuarios, Repositorios) en HTML estático y
+publica el resultado en la rama `gh-pages` usando
+[`peaceiris/actions-gh-pages@v4`](https://github.com/peaceiris/actions-gh-pages).
+
+Build:
+
+```bash
+npm run build:gh-pages
+# Genera dist/.../browser/{index.html, usuarios/index.html, repositorios/index.html}
+```
+
+Configuración en `angular.json` → `architect.build.configurations.gh-pages`:
+
+- `outputMode: "static"` — genera HTML pre-renderizado (sin servidor Node)
+- `baseHref: "/MISO-4104-ANGULAR-PRACTICE-ASSESSMENT/"` — necesario para
+  servir bajo el path del repo en `username.github.io/repo-name/`
+- Los datos de `Users` y `Repositories` se fetchan **en build time** desde
+  los gists; quedan embebidos en el HTML vía `TransferState`. El navegador
+  no necesita re-fetchearlos.
+
+**Setup inicial (una sola vez)**:
+
+1. Settings → Pages → Source = `Deploy from a branch` · Branch = `gh-pages` · `/ (root)`
+2. Tras el primer deploy exitoso, el sitio queda en
+   `https://<owner>.github.io/MISO-4104-ANGULAR-PRACTICE-ASSESSMENT/`
 
 **Convenciones de commit / título de PR** — para que el bump de versión
 funcione hay que usar Conventional Commits:

--- a/angular.json
+++ b/angular.json
@@ -54,6 +54,23 @@
               "optimization": false,
               "extractLicenses": false,
               "sourceMap": true
+            },
+            "gh-pages": {
+              "outputMode": "static",
+              "baseHref": "/MISO-4104-ANGULAR-PRACTICE-ASSESSMENT/",
+              "outputHashing": "all",
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "500kB",
+                  "maximumError": "1MB"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "8kB",
+                  "maximumError": "16kB"
+                }
+              ]
             }
           },
           "defaultConfiguration": "production"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
+    "build:gh-pages": "ng build --configuration gh-pages",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "test:watch": "ng test --watch",

--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -1,8 +1,17 @@
 import { RenderMode, type ServerRoute } from '@angular/ssr';
 
+/**
+ * Prerender para todas las rutas → genera HTML estático en build time.
+ * Compatible con outputMode:'static' (gh-pages) y outputMode:'server' (SSR
+ * que sirve el HTML pre-generado).
+ *
+ * Las llamadas HttpClient (`Users.list()`, `Repositories.list()`) se
+ * ejecutan durante el prerender; los datos se embeben en el HTML vía
+ * TransferState — el navegador hidrata sin volver a fetchear.
+ */
 export const serverRoutes: ServerRoute[] = [
   {
     path: '**',
-    renderMode: RenderMode.Server,
+    renderMode: RenderMode.Prerender,
   },
 ];


### PR DESCRIPTION
## Summary

Adds an automated static deploy to GitHub Pages on every merge to `main`.

### Cómo funciona
- **Prerender**: las 3 rutas (`/`, `/usuarios`, `/repositorios`) se renderizan a HTML estático en build time. Los `HttpClient.get(...)` corren en Node durante el build, los datos se embeben en el HTML vía `TransferState` → al hidratar en el browser, NO se vuelve a fetchear.
- **Build estático**: nueva configuración `gh-pages` en `angular.json` con `outputMode: "static"` y `baseHref: "/MISO-4104-ANGULAR-PRACTICE-ASSESSMENT/"`.
- **Publish**: `peaceiris/actions-gh-pages@v4` empuja `dist/.../browser` a la rama `gh-pages` con `force_orphan: true` (cada deploy reescribe — sin bloat de historial).

### Archivos
- **`src/app/app.routes.server.ts`** — `RenderMode.Server` → `RenderMode.Prerender` para `**`. Funciona tanto para SSR (`outputMode: server`) como para static (`outputMode: static`).
- **`angular.json`** — nueva configuration `gh-pages` que extiende production con `outputMode: static` + `baseHref`.
- **`package.json`** — script `build:gh-pages`.
- **`.github/workflows/deploy-pages.yml`** — workflow nuevo, dispara en `push: [main]` + `workflow_dispatch`.
- **`README.md`** — sección "Deploy" con instrucciones del setup único en Settings → Pages.

### Trade-off
Los datos quedan "frozen" al momento del build. Si los gists cambian, el sitio servido tiene los datos del último deploy. Cada PR a `main` re-deploya con datos frescos. Si en algún momento se quieren datos siempre frescos (fetch en browser), se reemplaza el observable del servicio con un `isPlatformBrowser` guard.

## Setup inicial requerido (una sola vez)
Tras mergear esta PR, el primer push a `main` ejecutará el workflow y creará la rama `gh-pages`. Después:

1. Repo → Settings → Pages → Source = **Deploy from a branch** → Branch = **gh-pages** → `/ (root)`
2. Esperar 1-2 minutos
3. Sitio disponible en `https://yoimar-uniandes.github.io/MISO-4104-ANGULAR-PRACTICE-ASSESSMENT/`

## Test plan

- [x] `npm run format:check` passes
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (23 tests)
- [x] `npm run build` (SSR production) passes
- [x] `npm run build:gh-pages` (prerender static) passes — genera 3 HTML estáticos con base-href correcto y títulos diferentes por ruta
- [ ] CI workflow passes
- [ ] `Validate PR source branch` passes
- [ ] After promotion to `main`: workflow `Deploy` corre, crea la rama `gh-pages`, sitio servible