### PR TITLE
feat(users): listado de usuarios con filtros, paginación y cards interactivas

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,38 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Compose de desarrollo — levanta el stage `development` del Dockerfile y
+# monta el código fuente para HMR. Uso:
+#   docker compose -f docker-compose.dev.yml up --build
+# Luego abre http://localhost:4200 para ver los cambios en /usuarios.
+# ─────────────────────────────────────────────────────────────────────────────
+
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: development
+    image: ghquerry-dev
+    container_name: ghquerry-dev
+    ports:
+      - '4200:4200'
+    environment:
+      # Polling del watcher dentro del contenedor (necesario en WSL/Docker
+      # Desktop donde los eventos inotify no atraviesan el bind mount).
+      NODE_ENV: development
+      CHOKIDAR_USEPOLLING: 'true'
+      WATCHPACK_POLLING: 'true'
+    volumes:
+      # Bind mount del proyecto para hot-reload.
+      - .:/app
+      # node_modules y caches viven en volúmenes nombrados → sobreescriben el
+      # bind mount y evitan choques entre node_modules del host (Linux/WSL) y
+      # los del contenedor.
+      - ghquerry_node_modules:/app/node_modules
+      - ghquerry_angular_cache:/app/.angular
+    init: true
+    stdin_open: true
+    tty: true
+
+volumes:
+  ghquerry_node_modules:
+  ghquerry_angular_cache:

--- a/src/app/features/users/users-page.css
+++ b/src/app/features/users/users-page.css
@@ -1,7 +1,7 @@
 :host {
-  /* Llena la altura visible debajo del navbar y del padding vertical
-     de .layout__main (2rem * 2). El paginator queda anclado al final
-     del viewport y el contenido (header + grid) se centra verticalmente. */
+  /* Llena el viewport visible debajo del navbar para que el paginator
+     quede anclado al borde inferior y el grid de cards pueda centrarse
+     verticalmente en el espacio sobrante. */
   display: flex;
   flex-direction: column;
   min-height: calc(100dvh - var(--layout-navbar-h, 4rem) - 4rem);
@@ -27,24 +27,63 @@
   min-height: 0;
 }
 
+.users-page__toolbar {
+  margin: var(--space-4) 0 0;
+}
+
 .users-page__main {
+  /* `flex: 1` empuja el paginator al fondo del viewport. Las cards quedan
+     alineadas arriba (`flex-start`) — una fila única se ve como la primera
+     fila de la grilla, no flotando en el centro vertical. */
   flex: 1;
   display: flex;
   flex-direction: column;
-  /* `safe center` evita que el header desaparezca por arriba si el
-     contenido no cabe verticalmente (cae a `start` en vez de clipear). */
-  justify-content: safe center;
-  gap: var(--space-6);
+  justify-content: flex-start;
   min-height: 0;
+  /* Padding-top grande → garantiza un gap visible entre el toolbar y la
+     grid aunque haya pocas cards. */
+  padding: clamp(2rem, 5vh, 4rem) 0 var(--space-6);
 }
 
 .users-page__paginator {
-  margin-top: var(--space-6);
+  margin-top: var(--space-2);
+  /* Negative bottom margin → el paginator queda más cerca del borde
+     inferior del viewport, recortando el padding del .layout__main. */
+  margin-bottom: calc(var(--space-3) * -1);
+  border-top: 1px solid var(--color-border);
+  /* Ligero respiro entre el hr y los botones. */
+  padding-top: var(--space-3);
 }
 
 /* ── Header ──────────────────────────────────────────────────────────── */
 .users-page__header {
   margin-bottom: 0;
+}
+
+.users-page__empty-action {
+  margin-top: var(--space-3);
+  padding: 0.5rem 1rem;
+  font: inherit;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text);
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease;
+}
+
+.users-page__empty-action:hover {
+  background: var(--c-uniandes-color-neutro-30);
+  border-color: var(--c-uniandes-color-neutro-50);
+}
+
+.users-page__empty-action:focus-visible {
+  outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
+  outline-offset: 2px;
 }
 
 .users-page__title {
@@ -70,21 +109,39 @@
 
 /* ── Responsive grid ─────────────────────────────────────────────────── */
 .users-grid {
+  /* Flex con justify-content:center → las cards se centran horizontalmente
+     en cada fila aunque la última no quede llena (1 sola card también). */
   list-style: none;
   margin: 0;
   padding: 0;
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(min(18rem, 100%), 1fr));
-  gap: var(--space-6);
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-content: flex-start;
+  gap: var(--space-8);
 }
 
 .users-grid__item {
-  display: block;
-  height: 100%;
+  /* `flex: 1 1 18rem` permite a las cards crecer y rellenar el ancho del
+     contenedor → cuando hay 3 cards en una fila, sus bordes coinciden con
+     los del toolbar. `max-width: 22rem` evita que una card sola se estire
+     demasiado en pantallas anchas. */
+  flex: 1 1 18rem;
+  max-width: 22rem;
+  min-width: 0;
   /* Animación escalonada de entrada */
   opacity: 0;
   transform: translateY(8px);
   animation: fadeUp 420ms cubic-bezier(0.2, 0, 0, 1) forwards;
+}
+
+/* En viewports donde solo cabe 1 columna (≤ 608 px de contenedor), la card
+   se extiende al ancho completo para alinearse con los bordes laterales
+   del toolbar. */
+@media (max-width: 640px) {
+  .users-grid__item {
+    max-width: 100%;
+  }
 }
 
 .users-grid__item:nth-child(1) {

--- a/src/app/features/users/users-page.css
+++ b/src/app/features/users/users-page.css
@@ -1,45 +1,188 @@
 :host {
-  display: block;
+  /* Llena la altura visible debajo del navbar y del padding vertical
+     de .layout__main (2rem * 2). El paginator queda anclado al final
+     del viewport y el contenido (header + grid) se centra verticalmente. */
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100dvh - var(--layout-navbar-h, 4rem) - 4rem);
+
   /* Estado inicial explícito → sin FOUC en SSR */
   opacity: 0;
   transform: translateY(16px);
   animation: pageEnter 600ms cubic-bezier(0.2, 0, 0, 1) forwards;
 }
 
-.users-page__title,
-.users-page__placeholder {
-  opacity: 0;
-  transform: translateY(14px);
-  animation: fadeUp 600ms cubic-bezier(0.2, 0, 0, 1) forwards;
-}
-.users-page__title {
-  animation-delay: 100ms;
-}
-.users-page__placeholder {
-  animation-delay: 220ms;
-}
-
 @media (prefers-reduced-motion: reduce) {
-  :host,
-  .users-page__title,
-  .users-page__placeholder {
+  :host {
     animation: none;
     opacity: 1;
     transform: none;
   }
 }
 
-.users-page__title {
-  font-size: clamp(1.75rem, 1.2rem + 1.5vw, 2.5rem);
-  margin: 0 0 0.75rem;
+.users-page {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
 }
 
-.users-page__placeholder {
+.users-page__main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  /* `safe center` evita que el header desaparezca por arriba si el
+     contenido no cabe verticalmente (cae a `start` en vez de clipear). */
+  justify-content: safe center;
+  gap: var(--space-6);
+  min-height: 0;
+}
+
+.users-page__paginator {
+  margin-top: var(--space-6);
+}
+
+/* ── Header ──────────────────────────────────────────────────────────── */
+.users-page__header {
+  margin-bottom: 0;
+}
+
+.users-page__title {
+  font-size: clamp(1.75rem, 1.2rem + 1.5vw, 2.5rem);
+  margin: 0 0 0.5rem;
+}
+
+.users-page__subtitle {
   margin: 0;
-  padding: 1rem 1.25rem;
+  color: var(--color-text-muted);
+  font-size: 0.9375rem;
+}
+
+.users-page__empty {
+  margin: 0;
+  padding: var(--space-6);
   border: 1px dashed var(--color-border);
   border-radius: 0.5rem;
   background: var(--color-surface);
   color: var(--color-text-muted);
-  font-size: 0.9375rem;
+  text-align: center;
+}
+
+/* ── Responsive grid ─────────────────────────────────────────────────── */
+.users-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(18rem, 100%), 1fr));
+  gap: var(--space-6);
+}
+
+.users-grid__item {
+  display: block;
+  height: 100%;
+  /* Animación escalonada de entrada */
+  opacity: 0;
+  transform: translateY(8px);
+  animation: fadeUp 420ms cubic-bezier(0.2, 0, 0, 1) forwards;
+}
+
+.users-grid__item:nth-child(1) {
+  animation-delay: 40ms;
+}
+.users-grid__item:nth-child(2) {
+  animation-delay: 80ms;
+}
+.users-grid__item:nth-child(3) {
+  animation-delay: 120ms;
+}
+.users-grid__item:nth-child(4) {
+  animation-delay: 160ms;
+}
+.users-grid__item:nth-child(5) {
+  animation-delay: 200ms;
+}
+.users-grid__item:nth-child(6) {
+  animation-delay: 240ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .users-grid__item {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* ── Skeleton mientras carga ─────────────────────────────────────────── */
+.user-skeleton {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-6);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 0.75rem;
+}
+
+.user-skeleton__avatar {
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 50%;
+  background: var(--c-uniandes-color-neutro-30);
+  position: relative;
+  overflow: hidden;
+}
+
+.user-skeleton__lines {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.user-skeleton__line {
+  height: 0.75rem;
+  border-radius: 0.25rem;
+  background: var(--c-uniandes-color-neutro-30);
+  position: relative;
+  overflow: hidden;
+}
+
+.user-skeleton__line--lg {
+  width: 70%;
+}
+.user-skeleton__line--md {
+  width: 50%;
+}
+.user-skeleton__line--sm {
+  width: 35%;
+}
+
+.user-skeleton__avatar::after,
+.user-skeleton__line::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.6) 50%,
+    transparent 100%
+  );
+  transform: translateX(-100%);
+  animation: shimmer 1.4s infinite;
+}
+
+@keyframes shimmer {
+  to {
+    transform: translateX(100%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .user-skeleton__avatar::after,
+  .user-skeleton__line::after {
+    animation: none;
+  }
 }

--- a/src/app/features/users/users-page.html
+++ b/src/app/features/users/users-page.html
@@ -1,14 +1,51 @@
 <section class="users-page" aria-labelledby="users-page-title">
-  <div class="users-page__main">
-    <header class="users-page__header">
-      <h1 id="users-page-title" class="users-page__title">{{ title }}</h1>
-      @if (!isLoading()) {
-        <p class="users-page__subtitle" aria-live="polite">
+  <header class="users-page__header">
+    <h1 id="users-page-title" class="users-page__title">{{ title }}</h1>
+    @if (!isLoading()) {
+      <p class="users-page__subtitle" aria-live="polite">
+        @if (hasActiveFilters()) {
+          {{ total() }} de {{ grandTotal() }} usuarios coinciden
+        } @else {
           {{ total() }} usuarios en la comunidad
-        </p>
-      }
-    </header>
+        }
+      </p>
+    }
+  </header>
 
+  <app-filter-toolbar
+    class="users-page__toolbar"
+    ariaLabel="Filtros de usuarios"
+    [hasActive]="hasActiveFilters()"
+    (clear)="onReset()"
+  >
+    <app-search-input
+      ariaLabel="Buscar por nombre o usuario"
+      placeholder="Buscar por nombre o usuario…"
+      [value]="query()"
+      (valueChange)="query.set($event)"
+    />
+    <app-chips-field
+      ariaLabel="Filtrar por rol"
+      [options]="roleOptions"
+      [value]="role()"
+      (valueChange)="role.set($event)"
+    />
+    <app-select-field
+      ariaLabel="Filtrar por ubicación"
+      placeholder="Todas las ubicaciones"
+      [options]="locationOptions()"
+      [value]="location()"
+      (valueChange)="location.set($event)"
+    />
+    <app-chips-field
+      ariaLabel="Filtrar por repositorios"
+      [options]="hasReposOptions"
+      [value]="hasRepos()"
+      (valueChange)="hasRepos.set($event)"
+    />
+  </app-filter-toolbar>
+
+  <div class="users-page__main">
     @if (isLoading()) {
       <ul class="users-grid" aria-label="Cargando usuarios" aria-busy="true">
         @for (slot of skeletonSlots; track slot) {
@@ -26,7 +63,14 @@
       </ul>
     } @else if (paged(); as pageUsers) {
       @if (pageUsers.length === 0) {
-        <p class="users-page__empty">No hay usuarios para mostrar.</p>
+        <div class="users-page__empty">
+          <p>No hay usuarios que coincidan con los filtros.</p>
+          @if (hasActiveFilters()) {
+            <button type="button" class="users-page__empty-action" (click)="onReset()">
+              Limpiar filtros
+            </button>
+          }
+        </div>
       } @else {
         <ul class="users-grid">
           @for (user of pageUsers; track user.id) {

--- a/src/app/features/users/users-page.html
+++ b/src/app/features/users/users-page.html
@@ -1,6 +1,51 @@
-<section class="users-page">
-  <h1 class="users-page__title">{{ title }}</h1>
-  <p class="users-page__placeholder">
-    Implementar componente para listar usuarios. HU pendiente de iteraciones posteriores.
-  </p>
+<section class="users-page" aria-labelledby="users-page-title">
+  <div class="users-page__main">
+    <header class="users-page__header">
+      <h1 id="users-page-title" class="users-page__title">{{ title }}</h1>
+      @if (!isLoading()) {
+        <p class="users-page__subtitle" aria-live="polite">
+          {{ total() }} usuarios en la comunidad
+        </p>
+      }
+    </header>
+
+    @if (isLoading()) {
+      <ul class="users-grid" aria-label="Cargando usuarios" aria-busy="true">
+        @for (slot of skeletonSlots; track slot) {
+          <li class="users-grid__item">
+            <div class="user-skeleton" aria-hidden="true">
+              <div class="user-skeleton__avatar"></div>
+              <div class="user-skeleton__lines">
+                <div class="user-skeleton__line user-skeleton__line--lg"></div>
+                <div class="user-skeleton__line user-skeleton__line--md"></div>
+                <div class="user-skeleton__line user-skeleton__line--sm"></div>
+              </div>
+            </div>
+          </li>
+        }
+      </ul>
+    } @else if (paged(); as pageUsers) {
+      @if (pageUsers.length === 0) {
+        <p class="users-page__empty">No hay usuarios para mostrar.</p>
+      } @else {
+        <ul class="users-grid">
+          @for (user of pageUsers; track user.id) {
+            <li class="users-grid__item">
+              <app-user-card [user]="user" />
+            </li>
+          }
+        </ul>
+      }
+    }
+  </div>
+
+  @if (!isLoading() && total() > pageSize) {
+    <app-paginator
+      class="users-page__paginator"
+      [total]="total()"
+      [pageSize]="pageSize"
+      [page]="page()"
+      (pageChange)="onPageChange($event)"
+    />
+  }
 </section>

--- a/src/app/features/users/users-page.ts
+++ b/src/app/features/users/users-page.ts
@@ -1,11 +1,42 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+
+import { UserCard } from '@shared/ui/user-card/user-card';
+import { Paginator } from '@shared/ui/paginator/paginator';
+import { Users } from './users';
 
 @Component({
   selector: 'app-users-page',
+  imports: [UserCard, Paginator],
   templateUrl: './users-page.html',
   styleUrl: './users-page.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class UsersPage {
+  private readonly usersService = inject(Users);
+
   protected readonly title = 'Usuarios';
+  protected readonly pageSize = 6;
+
+  protected readonly all = toSignal(this.usersService.list(), { initialValue: undefined });
+  protected readonly page = signal(1);
+
+  protected readonly total = computed(() => this.all()?.length ?? 0);
+  protected readonly isLoading = computed(() => this.all() === undefined);
+
+  protected readonly paged = computed(() => {
+    const list = this.all();
+    if (!list) return undefined;
+    const start = (this.page() - 1) * this.pageSize;
+    return list.slice(start, start + this.pageSize);
+  });
+
+  protected readonly skeletonSlots = Array.from({ length: this.pageSize }, (_, i) => i);
+
+  protected onPageChange(page: number): void {
+    this.page.set(page);
+    if (typeof window !== 'undefined') {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  }
 }

--- a/src/app/features/users/users-page.ts
+++ b/src/app/features/users/users-page.ts
@@ -1,13 +1,31 @@
-import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  signal,
+  untracked,
+} from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { debounceTime, distinctUntilChanged } from 'rxjs';
 
 import { UserCard } from '@shared/ui/user-card/user-card';
 import { Paginator } from '@shared/ui/paginator/paginator';
+import {
+  type ChipOption,
+  ChipsField,
+  FilterToolbar,
+  SearchInputField,
+  type SelectOption,
+  SelectField,
+} from '@shared/ui/filter-toolbar';
 import { Users } from './users';
+import type { Role, UserFilters } from './user';
 
 @Component({
   selector: 'app-users-page',
-  imports: [UserCard, Paginator],
+  imports: [UserCard, Paginator, FilterToolbar, SearchInputField, ChipsField, SelectField],
   templateUrl: './users-page.html',
   styleUrl: './users-page.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -18,14 +36,70 @@ export class UsersPage {
   protected readonly title = 'Usuarios';
   protected readonly pageSize = 6;
 
-  protected readonly all = toSignal(this.usersService.list(), { initialValue: undefined });
+  /* ── Estado de filtros ─────────────────────────────────────────────── */
+  protected readonly query = signal('');
+  protected readonly role = signal<Role | null>(null);
+  protected readonly location = signal<string | null>(null);
+  protected readonly hasRepos = signal<boolean | null>(null);
   protected readonly page = signal(1);
 
-  protected readonly total = computed(() => this.all()?.length ?? 0);
+  protected readonly roleOptions: ReadonlyArray<ChipOption<Role>> = [
+    { value: 'admin', label: 'Admin' },
+    { value: 'developer', label: 'Developer' },
+    { value: 'designer', label: 'Designer' },
+  ];
+
+  protected readonly hasReposOptions: ReadonlyArray<ChipOption<boolean>> = [
+    { value: true, label: 'Con repos' },
+    { value: false, label: 'Sin repos' },
+  ];
+
+  /* ── Datos ─────────────────────────────────────────────────────────── */
+  private readonly all = toSignal(this.usersService.list(), { initialValue: undefined });
+
+  /* Debounce sólo del input de texto; el resto se aplica al instante. */
+  private readonly debouncedQuery = toSignal(
+    toObservable(this.query).pipe(debounceTime(200), distinctUntilChanged()),
+    { initialValue: '' },
+  );
+
+  protected readonly filters = computed<UserFilters>(() => {
+    const f: { -readonly [K in keyof UserFilters]?: UserFilters[K] } = {};
+    const q = this.debouncedQuery().trim();
+    if (q.length > 0) f.query = q;
+    const r = this.role();
+    if (r !== null) f.role = r;
+    const loc = this.location();
+    if (loc !== null) f.location = loc;
+    const hr = this.hasRepos();
+    if (hr !== null) f.hasRepos = hr;
+    return f;
+  });
+
+  protected readonly hasActiveFilters = computed(() => Object.keys(this.filters()).length > 0);
+
+  protected readonly filtered = computed(() => {
+    const list = this.all();
+    if (!list) return undefined;
+    return list.filter((u) => u.matches(this.filters()));
+  });
+
+  protected readonly locationOptions = computed<ReadonlyArray<SelectOption<string>>>(() => {
+    const list = this.all();
+    if (!list) return [];
+    const seen = new Set<string>();
+    for (const u of list) seen.add(u.location);
+    return Array.from(seen)
+      .sort((a, b) => a.localeCompare(b, 'es'))
+      .map((loc) => ({ value: loc, label: loc }));
+  });
+
+  protected readonly total = computed(() => this.filtered()?.length ?? 0);
+  protected readonly grandTotal = computed(() => this.all()?.length ?? 0);
   protected readonly isLoading = computed(() => this.all() === undefined);
 
   protected readonly paged = computed(() => {
-    const list = this.all();
+    const list = this.filtered();
     if (!list) return undefined;
     const start = (this.page() - 1) * this.pageSize;
     return list.slice(start, start + this.pageSize);
@@ -33,10 +107,27 @@ export class UsersPage {
 
   protected readonly skeletonSlots = Array.from({ length: this.pageSize }, (_, i) => i);
 
+  constructor() {
+    /* Cualquier cambio en filtros nos devuelve a la página 1. */
+    effect(() => {
+      this.filters();
+      untracked(() => {
+        this.page.set(1);
+      });
+    });
+  }
+
   protected onPageChange(page: number): void {
     this.page.set(page);
     if (typeof window !== 'undefined') {
       window.scrollTo({ top: 0, behavior: 'smooth' });
     }
+  }
+
+  protected onReset(): void {
+    this.query.set('');
+    this.role.set(null);
+    this.location.set(null);
+    this.hasRepos.set(null);
   }
 }

--- a/src/app/shared/ui/filter-toolbar/chips-field.css
+++ b/src/app/shared/ui/filter-toolbar/chips-field.css
@@ -1,0 +1,45 @@
+:host {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.chips-field__chip {
+  display: inline-flex;
+  align-items: center;
+  height: 2.25rem;
+  padding: 0 0.875rem;
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--color-text);
+  background: var(--c-uniandes-color-neutro-30);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  cursor: pointer;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease;
+}
+
+.chips-field__chip:hover {
+  background: var(--c-uniandes-color-neutro-40);
+  border-color: var(--c-uniandes-color-neutro-50);
+}
+
+.chips-field__chip:focus-visible {
+  outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
+  outline-offset: 2px;
+}
+
+.chips-field__chip--active {
+  background: var(--c-background-primary-default-lightbg);
+  color: var(--c-content-primary-default-lightbg);
+  border-color: var(--c-background-primary-default-lightbg);
+}
+
+.chips-field__chip--active:hover {
+  background: var(--c-background-primary-default-lightbg);
+  border-color: var(--c-background-primary-default-lightbg);
+}

--- a/src/app/shared/ui/filter-toolbar/chips-field.html
+++ b/src/app/shared/ui/filter-toolbar/chips-field.html
@@ -1,0 +1,11 @@
+@for (opt of options(); track $index) {
+  <button
+    type="button"
+    class="chips-field__chip"
+    [class.chips-field__chip--active]="isActive(opt)"
+    [attr.aria-pressed]="isActive(opt)"
+    (click)="onClick(opt)"
+  >
+    {{ opt.label }}
+  </button>
+}

--- a/src/app/shared/ui/filter-toolbar/chips-field.ts
+++ b/src/app/shared/ui/filter-toolbar/chips-field.ts
@@ -1,0 +1,40 @@
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+
+export interface ChipOption<T> {
+  readonly value: T;
+  readonly label: string;
+}
+
+/**
+ * Selector tipo "chips" — un valor activo a la vez (o ninguno).
+ * Re-clickear el chip activo lo deselecciona y emite `null`.
+ *
+ * Genérico en `T` para reutilizarlo con cualquier dominio de valor primitivo
+ * (string union, boolean, number, etc.).
+ */
+@Component({
+  selector: 'app-chips-field',
+  templateUrl: './chips-field.html',
+  styleUrl: './chips-field.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    role: 'group',
+    '[attr.aria-label]': 'ariaLabel()',
+    class: 'chips-field',
+  },
+})
+export class ChipsField<T> {
+  readonly options = input.required<ReadonlyArray<ChipOption<T>>>();
+  readonly value = input<T | null>(null);
+  readonly ariaLabel = input.required<string>();
+
+  readonly valueChange = output<T | null>();
+
+  protected isActive(option: ChipOption<T>): boolean {
+    return this.value() === option.value;
+  }
+
+  protected onClick(option: ChipOption<T>): void {
+    this.valueChange.emit(this.isActive(option) ? null : option.value);
+  }
+}

--- a/src/app/shared/ui/filter-toolbar/filter-toolbar.css
+++ b/src/app/shared/ui/filter-toolbar/filter-toolbar.css
@@ -1,0 +1,74 @@
+:host {
+  display: flex;
+  /* Top-aligned: el botón "Limpiar filtros" queda arriba a la derecha,
+     en línea con la primera fila de filtros, sin importar si los campos
+     se envuelven a varias filas. */
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 0.75rem;
+}
+
+.filter-toolbar__fields {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+  flex: 1;
+  min-width: 0;
+}
+
+.filter-toolbar__reset {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  margin-left: auto;
+  height: 2.25rem;
+  padding: 0 0.75rem;
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--color-text);
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease;
+}
+
+.filter-toolbar__reset:hover {
+  background: var(--c-uniandes-color-neutro-30);
+  border-color: var(--c-uniandes-color-neutro-50);
+}
+
+.filter-toolbar__reset:focus-visible {
+  outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
+  outline-offset: 2px;
+}
+
+/* Reservamos el espacio del botón aunque no haya filtros activos para que
+   no haya saltos de layout cuando aparece/desaparece. */
+.filter-toolbar__reset--hidden {
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.filter-toolbar__reset-icon {
+  width: 0.875rem;
+  height: 0.875rem;
+}
+
+@media (max-width: 640px) {
+  .filter-toolbar__reset {
+    margin-left: 0;
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/src/app/shared/ui/filter-toolbar/filter-toolbar.html
+++ b/src/app/shared/ui/filter-toolbar/filter-toolbar.html
@@ -1,0 +1,23 @@
+<div class="filter-toolbar__fields">
+  <ng-content />
+</div>
+
+<button
+  type="button"
+  class="filter-toolbar__reset"
+  [class.filter-toolbar__reset--hidden]="!hasActive()"
+  [attr.aria-hidden]="!hasActive() ? 'true' : null"
+  [attr.tabindex]="!hasActive() ? -1 : null"
+  (click)="onClear()"
+>
+  <svg class="filter-toolbar__reset-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+    <path
+      d="M18 6 6 18M6 6l12 12"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+    />
+  </svg>
+  {{ resetLabel() }}
+</button>

--- a/src/app/shared/ui/filter-toolbar/filter-toolbar.ts
+++ b/src/app/shared/ui/filter-toolbar/filter-toolbar.ts
@@ -1,0 +1,31 @@
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+
+/**
+ * Shell de toolbar de filtros — agnóstico al dominio.
+ *
+ * Provee layout responsive (flex-wrap) y el botón "Limpiar" que se muestra
+ * sólo cuando hay filtros activos. Los campos concretos (search, chips,
+ * select, etc.) se proyectan vía `<ng-content>`.
+ */
+@Component({
+  selector: 'app-filter-toolbar',
+  templateUrl: './filter-toolbar.html',
+  styleUrl: './filter-toolbar.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    role: 'group',
+    '[attr.aria-label]': 'ariaLabel()',
+    class: 'filter-toolbar',
+  },
+})
+export class FilterToolbar {
+  readonly ariaLabel = input('Filtros');
+  readonly hasActive = input(false);
+  readonly resetLabel = input('Limpiar filtros');
+
+  readonly clear = output();
+
+  protected onClear(): void {
+    this.clear.emit();
+  }
+}

--- a/src/app/shared/ui/filter-toolbar/index.ts
+++ b/src/app/shared/ui/filter-toolbar/index.ts
@@ -1,0 +1,4 @@
+export { FilterToolbar } from './filter-toolbar';
+export { SearchInputField } from './search-input-field';
+export { ChipsField, type ChipOption } from './chips-field';
+export { SelectField, type SelectOption } from './select-field';

--- a/src/app/shared/ui/filter-toolbar/search-input-field.css
+++ b/src/app/shared/ui/filter-toolbar/search-input-field.css
@@ -1,0 +1,91 @@
+:host {
+  display: block;
+  flex: 1 1 16rem;
+  min-width: 12rem;
+}
+
+.search-input__wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.search-input__icon {
+  position: absolute;
+  left: 0.625rem;
+  width: 1rem;
+  height: 1rem;
+  color: var(--c-uniandes-color-neutro-70);
+  pointer-events: none;
+}
+
+.search-input__control {
+  width: 100%;
+  height: 2.25rem;
+  padding: 0 2rem 0 2.25rem;
+  font: inherit;
+  font-size: 0.875rem;
+  color: var(--color-text);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.search-input__control::placeholder {
+  color: var(--color-text-disabled);
+}
+
+.search-input__control:hover {
+  border-color: var(--c-uniandes-color-neutro-50);
+}
+
+.search-input__control:focus-visible {
+  outline: none;
+  border-color: var(--c-border-secondary-default-lightbg);
+  box-shadow: 0 0 0 2px var(--c-uniandes-color-secondary-01-lightbg);
+}
+
+/* Oculta la X nativa que añaden algunos navegadores en input[type=search]. */
+.search-input__control::-webkit-search-decoration,
+.search-input__control::-webkit-search-cancel-button,
+.search-input__control::-webkit-search-results-button,
+.search-input__control::-webkit-search-results-decoration {
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.search-input__clear {
+  position: absolute;
+  right: 0.375rem;
+  display: inline-grid;
+  place-items: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  padding: 0;
+  color: var(--color-text-muted);
+  background: transparent;
+  border: none;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  transition:
+    background-color 160ms ease,
+    color 160ms ease;
+}
+
+.search-input__clear:hover {
+  background: var(--c-uniandes-color-neutro-30);
+  color: var(--color-text);
+}
+
+.search-input__clear:focus-visible {
+  outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
+  outline-offset: 1px;
+}
+
+.search-input__clear svg {
+  width: 0.75rem;
+  height: 0.75rem;
+}

--- a/src/app/shared/ui/filter-toolbar/search-input-field.html
+++ b/src/app/shared/ui/filter-toolbar/search-input-field.html
@@ -1,0 +1,37 @@
+<div class="search-input__wrap">
+  <svg class="search-input__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+    <path
+      d="M10 4a6 6 0 1 0 3.74 10.7l4.78 4.78 1.41-1.41-4.78-4.78A6 6 0 0 0 10 4zm0 2a4 4 0 1 1 0 8 4 4 0 0 1 0-8z"
+      fill="currentColor"
+    />
+  </svg>
+  <input
+    class="search-input__control"
+    type="search"
+    autocomplete="off"
+    spellcheck="false"
+    [id]="resolvedId()"
+    [value]="value()"
+    [placeholder]="placeholder()"
+    [attr.aria-label]="ariaLabel()"
+    (input)="onInput($event)"
+  />
+  @if (value().length > 0) {
+    <button
+      type="button"
+      class="search-input__clear"
+      (click)="onClear()"
+      aria-label="Borrar búsqueda"
+    >
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path
+          d="M18 6 6 18M6 6l12 12"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+        />
+      </svg>
+    </button>
+  }
+</div>

--- a/src/app/shared/ui/filter-toolbar/search-input-field.ts
+++ b/src/app/shared/ui/filter-toolbar/search-input-field.ts
@@ -1,0 +1,31 @@
+import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
+
+let nextSearchId = 0;
+
+@Component({
+  selector: 'app-search-input',
+  templateUrl: './search-input-field.html',
+  styleUrl: './search-input-field.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { class: 'search-input' },
+})
+export class SearchInputField {
+  readonly value = input.required<string>();
+  readonly placeholder = input('Buscar…');
+  readonly ariaLabel = input.required<string>();
+  readonly inputId = input<string | null>(null);
+
+  readonly valueChange = output<string>();
+
+  protected readonly fallbackId = `app-search-${String(++nextSearchId)}`;
+  protected readonly resolvedId = computed(() => this.inputId() ?? this.fallbackId);
+
+  protected onInput(event: Event): void {
+    const target = event.target as HTMLInputElement;
+    this.valueChange.emit(target.value);
+  }
+
+  protected onClear(): void {
+    this.valueChange.emit('');
+  }
+}

--- a/src/app/shared/ui/filter-toolbar/select-field.css
+++ b/src/app/shared/ui/filter-toolbar/select-field.css
@@ -1,0 +1,49 @@
+:host {
+  display: inline-flex;
+  flex: 1 1 12rem;
+  min-width: 10rem;
+}
+
+.select-field__wrap {
+  position: relative;
+  display: inline-flex;
+  width: 100%;
+  align-items: center;
+}
+
+.select-field__control {
+  width: 100%;
+  height: 2.25rem;
+  padding: 0 2rem 0 0.75rem;
+  font: inherit;
+  font-size: 0.875rem;
+  color: var(--color-text);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  appearance: none;
+  -webkit-appearance: none;
+  cursor: pointer;
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.select-field__control:hover {
+  border-color: var(--c-uniandes-color-neutro-50);
+}
+
+.select-field__control:focus-visible {
+  outline: none;
+  border-color: var(--c-border-secondary-default-lightbg);
+  box-shadow: 0 0 0 2px var(--c-uniandes-color-secondary-01-lightbg);
+}
+
+.select-field__chevron {
+  position: absolute;
+  right: 0.625rem;
+  width: 1rem;
+  height: 1rem;
+  color: var(--c-uniandes-color-neutro-70);
+  pointer-events: none;
+}

--- a/src/app/shared/ui/filter-toolbar/select-field.html
+++ b/src/app/shared/ui/filter-toolbar/select-field.html
@@ -1,0 +1,23 @@
+<div class="select-field__wrap">
+  <select
+    class="select-field__control"
+    [value]="value() ?? ''"
+    [attr.aria-label]="ariaLabel()"
+    (change)="onChange($event)"
+  >
+    <option value="">{{ placeholder() }}</option>
+    @for (opt of options(); track $index) {
+      <option [value]="opt.value">{{ opt.label }}</option>
+    }
+  </select>
+  <svg class="select-field__chevron" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+    <path
+      d="m6 9 6 6 6-6"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </svg>
+</div>

--- a/src/app/shared/ui/filter-toolbar/select-field.ts
+++ b/src/app/shared/ui/filter-toolbar/select-field.ts
@@ -1,0 +1,31 @@
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+
+export interface SelectOption<T extends string> {
+  readonly value: T;
+  readonly label: string;
+}
+
+/**
+ * `<select>` controlado con placeholder.
+ * Cuando el usuario elige el placeholder (cadena vacía) se emite `null`.
+ */
+@Component({
+  selector: 'app-select-field',
+  templateUrl: './select-field.html',
+  styleUrl: './select-field.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { class: 'select-field' },
+})
+export class SelectField<T extends string = string> {
+  readonly options = input.required<ReadonlyArray<SelectOption<T>>>();
+  readonly value = input<T | null>(null);
+  readonly placeholder = input('Todos');
+  readonly ariaLabel = input.required<string>();
+
+  readonly valueChange = output<T | null>();
+
+  protected onChange(event: Event): void {
+    const selected = (event.target as HTMLSelectElement).value;
+    this.valueChange.emit(selected === '' ? null : (selected as T));
+  }
+}

--- a/src/app/shared/ui/paginator/paginator.css
+++ b/src/app/shared/ui/paginator/paginator.css
@@ -1,0 +1,116 @@
+:host {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  padding: var(--space-4) 0;
+}
+
+.paginator__list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-1);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.paginator__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  min-width: 2.25rem;
+  height: 2.25rem;
+  padding: 0 0.625rem;
+  font: inherit;
+  font-weight: 500;
+  font-size: 0.875rem;
+  color: var(--color-text);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease,
+    transform 160ms ease;
+}
+
+.paginator__btn:hover:not(:disabled) {
+  background: var(--c-uniandes-color-neutro-30);
+  border-color: var(--c-uniandes-color-neutro-50);
+}
+
+.paginator__btn:focus-visible {
+  outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
+  outline-offset: 2px;
+}
+
+.paginator__btn:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
+.paginator__btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.paginator__btn--active {
+  background: var(--c-background-primary-default-lightbg);
+  color: var(--c-content-primary-default-lightbg);
+  border-color: var(--c-background-primary-default-lightbg);
+}
+
+.paginator__btn--active:hover:not(:disabled) {
+  background: var(--c-background-primary-default-lightbg);
+  color: var(--c-content-primary-default-lightbg);
+  border-color: var(--c-background-primary-default-lightbg);
+}
+
+.paginator__btn--nav {
+  font-weight: 500;
+}
+
+.paginator__gap {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.75rem;
+  height: 2.25rem;
+  color: var(--color-text-muted);
+  user-select: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .paginator__btn {
+    transition: none;
+  }
+  .paginator__btn:active:not(:disabled) {
+    transform: none;
+  }
+}
+
+/* En pantallas estrechas ocultamos el texto "Anterior/Siguiente" y dejamos solo
+   las flechas para no romper la alineación de la lista de páginas. */
+@media (max-width: 480px) {
+  .paginator__btn-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+  .paginator__btn--nav {
+    min-width: 2.25rem;
+    padding: 0;
+  }
+}

--- a/src/app/shared/ui/paginator/paginator.html
+++ b/src/app/shared/ui/paginator/paginator.html
@@ -1,0 +1,42 @@
+<button
+  type="button"
+  class="paginator__btn paginator__btn--nav"
+  (click)="prev()"
+  [disabled]="!canPrev()"
+  aria-label="Página anterior"
+>
+  <span aria-hidden="true">&lsaquo;</span>
+  <span class="paginator__btn-label">Anterior</span>
+</button>
+
+<ul class="paginator__list">
+  @for (item of pages(); track $index) {
+    @if (item === 'gap') {
+      <li class="paginator__gap" aria-hidden="true">…</li>
+    } @else {
+      <li>
+        <button
+          type="button"
+          class="paginator__btn paginator__btn--page"
+          [class.paginator__btn--active]="item === current()"
+          [attr.aria-current]="item === current() ? 'page' : null"
+          [attr.aria-label]="'Ir a la página ' + item"
+          (click)="goTo(item)"
+        >
+          {{ item }}
+        </button>
+      </li>
+    }
+  }
+</ul>
+
+<button
+  type="button"
+  class="paginator__btn paginator__btn--nav"
+  (click)="next()"
+  [disabled]="!canNext()"
+  aria-label="Página siguiente"
+>
+  <span class="paginator__btn-label">Siguiente</span>
+  <span aria-hidden="true">&rsaquo;</span>
+</button>

--- a/src/app/shared/ui/paginator/paginator.ts
+++ b/src/app/shared/ui/paginator/paginator.ts
@@ -1,0 +1,85 @@
+import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
+
+type PageItem = number | 'gap';
+
+@Component({
+  selector: 'app-paginator',
+  templateUrl: './paginator.html',
+  styleUrl: './paginator.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    role: 'navigation',
+    '[attr.aria-label]': 'ariaLabel()',
+    class: 'paginator',
+  },
+})
+export class Paginator {
+  readonly total = input.required<number>();
+  readonly pageSize = input.required<number>();
+  readonly page = input.required<number>();
+  readonly siblingCount = input(1);
+  readonly ariaLabel = input('Paginación');
+
+  readonly pageChange = output<number>();
+
+  protected readonly pageCount = computed(() =>
+    Math.max(1, Math.ceil(this.total() / this.pageSize())),
+  );
+
+  protected readonly current = computed(() => Math.min(Math.max(1, this.page()), this.pageCount()));
+
+  protected readonly canPrev = computed(() => this.current() > 1);
+  protected readonly canNext = computed(() => this.current() < this.pageCount());
+
+  protected readonly pages = computed<readonly PageItem[]>(() => {
+    const last = this.pageCount();
+    const cur = this.current();
+    const sib = this.siblingCount();
+    const totalNumbers = sib * 2 + 5;
+
+    if (last <= totalNumbers) {
+      return Array.from({ length: last }, (_, i) => i + 1);
+    }
+
+    const leftSib = Math.max(cur - sib, 1);
+    const rightSib = Math.min(cur + sib, last);
+    const showLeftGap = leftSib > 2;
+    const showRightGap = rightSib < last - 1;
+
+    const items: PageItem[] = [1];
+
+    if (showLeftGap) {
+      items.push('gap');
+    } else {
+      for (let i = 2; i < leftSib; i++) items.push(i);
+    }
+
+    for (let i = leftSib; i <= rightSib; i++) {
+      if (i !== 1 && i !== last) items.push(i);
+    }
+
+    if (showRightGap) {
+      items.push('gap');
+    } else {
+      for (let i = rightSib + 1; i < last; i++) items.push(i);
+    }
+
+    items.push(last);
+    return items;
+  });
+
+  protected goTo(page: number): void {
+    const target = Math.min(Math.max(1, page), this.pageCount());
+    if (target !== this.current()) {
+      this.pageChange.emit(target);
+    }
+  }
+
+  protected prev(): void {
+    if (this.canPrev()) this.goTo(this.current() - 1);
+  }
+
+  protected next(): void {
+    if (this.canNext()) this.goTo(this.current() + 1);
+  }
+}

--- a/src/app/shared/ui/user-card/user-card.css
+++ b/src/app/shared/ui/user-card/user-card.css
@@ -44,6 +44,16 @@
   gap: var(--space-3);
 }
 
+/* Stage del avatar: provee la perspectiva 3D para el efecto de tilt y
+   reserva exactamente el tamaño del avatar para que el cursor entre/salga
+   en sus bordes naturales. */
+.user-card__avatar-stage {
+  width: 3.5rem;
+  height: 3.5rem;
+  flex-shrink: 0;
+  perspective: 600px;
+}
+
 .user-card__avatar {
   width: 3.5rem;
   height: 3.5rem;
@@ -52,6 +62,18 @@
   background: var(--c-uniandes-color-neutro-30);
   border: 2px solid var(--color-bg);
   box-shadow: 0 0 0 1px var(--color-border);
+  transform-origin: center;
+  transition: transform 160ms cubic-bezier(0.2, 0, 0, 1);
+  will-change: transform;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .user-card__avatar {
+    transition: none;
+    /* `!important` cancela el inline `[style.transform]` para que la
+       lectura visual sea estática cuando el usuario lo prefiere. */
+    transform: none !important;
+  }
 }
 
 .user-card__avatar--initials {
@@ -181,6 +203,29 @@
 
 .user-card__email {
   color: var(--color-accent);
+}
+
+.user-card__location,
+.user-card__location:visited {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  /* Hereda `--color-text-muted` del parent para que la ubicación no compita
+     visualmente con el email (que sí usa el accent azul). El subrayado en
+     hover deja claro que es interactivo. */
+  color: inherit;
+  text-decoration: none;
+  transition: color 160ms ease;
+}
+
+.user-card__location:hover,
+.user-card__location:focus-visible {
+  color: var(--color-text);
+}
+
+.user-card__location:hover span {
+  text-decoration: underline;
 }
 
 .user-card__email:hover,

--- a/src/app/shared/ui/user-card/user-card.css
+++ b/src/app/shared/ui/user-card/user-card.css
@@ -1,0 +1,232 @@
+:host {
+  display: block;
+  height: 100%;
+}
+
+.user-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  height: 100%;
+  padding: var(--space-6);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 0.75rem;
+  box-shadow: 0 1px 2px rgba(25, 25, 22, 0.04);
+  transition:
+    transform 220ms cubic-bezier(0.2, 0, 0, 1),
+    box-shadow 220ms cubic-bezier(0.2, 0, 0, 1),
+    border-color 220ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+.user-card:hover,
+.user-card:focus-within {
+  transform: translateY(-2px);
+  border-color: var(--c-uniandes-color-neutro-50);
+  box-shadow: 0 6px 18px rgba(25, 25, 22, 0.08);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .user-card {
+    transition: none;
+  }
+  .user-card:hover,
+  .user-card:focus-within {
+    transform: none;
+  }
+}
+
+/* ── Header ──────────────────────────────────────────────────────────── */
+.user-card__header {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.user-card__avatar {
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 50%;
+  object-fit: cover;
+  background: var(--c-uniandes-color-neutro-30);
+  border: 2px solid var(--color-bg);
+  box-shadow: 0 0 0 1px var(--color-border);
+}
+
+.user-card__avatar--initials {
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  font-size: 1.125rem;
+  color: var(--color-text);
+  background: var(--c-uniandes-color-secondary-02-lightbg);
+}
+
+.user-card__identity {
+  min-width: 0;
+}
+
+.user-card__name {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+  color: var(--color-text);
+  /* `fit-content` con tope al ancho del contenedor → el elemento mide
+     exactamente el largo del nombre (o el ancho disponible si lo excede),
+     y el subrayado amarillo del :hover se ajusta al texto. */
+  width: fit-content;
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.user-card:hover .user-card__name,
+.user-card:focus-within .user-card__name {
+  background-image: linear-gradient(
+    var(--c-uniandes-color-secondary-01-lightbg),
+    var(--c-uniandes-color-secondary-01-lightbg)
+  );
+  background-repeat: no-repeat;
+  background-position: 0 88%;
+  background-size: 100% 0.35em;
+}
+
+.user-card__username {
+  margin: 0.125rem 0 0;
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+  font-feature-settings: 'tnum' 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── Role chip ───────────────────────────────────────────────────────── */
+.user-card__role {
+  align-self: start;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.user-card__role--admin {
+  background: var(--c-uniandes-color-secondary-02-lightbg);
+  color: var(--c-uniandes-color-primarytext-lightbg);
+  border-color: var(--c-uniandes-color-secondary-01-lightbg);
+}
+
+.user-card__role--developer {
+  background: var(--c-uniandes-color-neutro-30);
+  color: var(--c-uniandes-color-primarytext-lightbg);
+  border-color: var(--color-border);
+}
+
+.user-card__role--designer {
+  background: rgba(36, 66, 178, 0.08);
+  color: var(--color-accent);
+  border-color: rgba(36, 66, 178, 0.25);
+}
+
+/* ── Meta (location + email) ─────────────────────────────────────────── */
+.user-card__meta {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  font-size: 0.875rem;
+}
+
+.user-card__meta-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.user-card__meta-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.user-card__meta-value {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  color: var(--color-text-muted);
+}
+
+.user-card__meta-value > span,
+.user-card__email {
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.user-card__email {
+  color: var(--color-accent);
+}
+
+.user-card__email:hover,
+.user-card__email:focus-visible {
+  text-decoration: underline;
+}
+
+.user-card__icon {
+  flex-shrink: 0;
+  width: 1rem;
+  height: 1rem;
+  color: var(--c-uniandes-color-neutro-70);
+}
+
+/* ── Footer (repo badge) ─────────────────────────────────────────────── */
+.user-card__footer {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--color-border);
+}
+
+.user-card__repos {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--color-text);
+  padding: 0.25rem 0.625rem;
+  border-radius: 999px;
+  background: var(--c-uniandes-color-neutro-30);
+}
+
+.user-card__repos--empty {
+  color: var(--color-text-muted);
+  background: transparent;
+  border: 1px dashed var(--color-border);
+}
+
+/* Focus visibility for any interactive child */
+.user-card a:focus-visible,
+.user-card button:focus-visible {
+  outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
+  outline-offset: 3px;
+  border-radius: 0.25rem;
+}

--- a/src/app/shared/ui/user-card/user-card.html
+++ b/src/app/shared/ui/user-card/user-card.html
@@ -1,0 +1,71 @@
+<article class="user-card" [attr.aria-labelledby]="'user-' + user().id + '-name'">
+  <header class="user-card__header">
+    @if (avatarFailed()) {
+      <div class="user-card__avatar user-card__avatar--initials" aria-hidden="true">
+        {{ initials() }}
+      </div>
+    } @else {
+      <img
+        class="user-card__avatar"
+        [src]="user().avatarUrl"
+        [alt]="'Avatar de ' + user().name"
+        width="64"
+        height="64"
+        loading="lazy"
+        decoding="async"
+        (error)="onAvatarError()"
+      />
+    }
+    <div class="user-card__identity">
+      <h3 [id]="'user-' + user().id + '-name'" class="user-card__name">{{ user().name }}</h3>
+      <p class="user-card__username">&#64;{{ user().username }}</p>
+    </div>
+    <span
+      class="user-card__role user-card__role--{{ user().role }}"
+      [attr.aria-label]="'Rol: ' + roleLabel()"
+    >
+      {{ roleLabel() }}
+    </span>
+  </header>
+
+  <dl class="user-card__meta">
+    <div class="user-card__meta-row">
+      <dt class="user-card__meta-label">Ubicación</dt>
+      <dd class="user-card__meta-value">
+        <svg class="user-card__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            d="M12 2a7 7 0 0 0-7 7c0 5.25 7 13 7 13s7-7.75 7-13a7 7 0 0 0-7-7zm0 9.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5z"
+            fill="currentColor"
+          />
+        </svg>
+        <span>{{ user().location }}</span>
+      </dd>
+    </div>
+    <div class="user-card__meta-row">
+      <dt class="user-card__meta-label">Email</dt>
+      <dd class="user-card__meta-value">
+        <svg class="user-card__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            d="M4 4h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2zm0 4.4V18h16V8.4l-8 5-8-5z"
+            fill="currentColor"
+          />
+        </svg>
+        <a class="user-card__email" [href]="'mailto:' + user().email" [title]="user().email">
+          {{ user().email }}
+        </a>
+      </dd>
+    </div>
+  </dl>
+
+  <footer class="user-card__footer">
+    <span class="user-card__repos" [class.user-card__repos--empty]="user().repoIds.length === 0">
+      <svg class="user-card__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path
+          d="M7 3a2 2 0 0 0-2 2v15a1 1 0 0 0 1.5.87L12 17.6l5.5 3.27A1 1 0 0 0 19 20V5a2 2 0 0 0-2-2H7zm0 2h10v13.27l-4.5-2.68a1 1 0 0 0-1 0L7 18.27V5z"
+          fill="currentColor"
+        />
+      </svg>
+      {{ repoLabel() }}
+    </span>
+  </footer>
+</article>

--- a/src/app/shared/ui/user-card/user-card.html
+++ b/src/app/shared/ui/user-card/user-card.html
@@ -1,21 +1,36 @@
 <article class="user-card" [attr.aria-labelledby]="'user-' + user().id + '-name'">
   <header class="user-card__header">
-    @if (avatarFailed()) {
-      <div class="user-card__avatar user-card__avatar--initials" aria-hidden="true">
-        {{ initials() }}
-      </div>
-    } @else {
-      <img
-        class="user-card__avatar"
-        [src]="user().avatarUrl"
-        [alt]="'Avatar de ' + user().name"
-        width="64"
-        height="64"
-        loading="lazy"
-        decoding="async"
-        (error)="onAvatarError()"
-      />
-    }
+    <div
+      class="user-card__avatar-stage"
+      (mousemove)="onAvatarMove($event)"
+      (mouseleave)="onAvatarLeave()"
+    >
+      @if (avatarFailed()) {
+        <div
+          class="user-card__avatar user-card__avatar--initials"
+          [style.transform]="
+            'rotateX(' + tilt().x + 'deg) rotateY(' + tilt().y + 'deg) scale(' + tilt().scale + ')'
+          "
+          aria-hidden="true"
+        >
+          {{ initials() }}
+        </div>
+      } @else {
+        <img
+          class="user-card__avatar"
+          [src]="user().avatarUrl"
+          [alt]="'Avatar de ' + user().name"
+          [style.transform]="
+            'rotateX(' + tilt().x + 'deg) rotateY(' + tilt().y + 'deg) scale(' + tilt().scale + ')'
+          "
+          width="64"
+          height="64"
+          loading="lazy"
+          decoding="async"
+          (error)="onAvatarError()"
+        />
+      }
+    </div>
     <div class="user-card__identity">
       <h3 [id]="'user-' + user().id + '-name'" class="user-card__name">{{ user().name }}</h3>
       <p class="user-card__username">&#64;{{ user().username }}</p>
@@ -32,13 +47,21 @@
     <div class="user-card__meta-row">
       <dt class="user-card__meta-label">Ubicación</dt>
       <dd class="user-card__meta-value">
-        <svg class="user-card__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-          <path
-            d="M12 2a7 7 0 0 0-7 7c0 5.25 7 13 7 13s7-7.75 7-13a7 7 0 0 0-7-7zm0 9.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5z"
-            fill="currentColor"
-          />
-        </svg>
-        <span>{{ user().location }}</span>
+        <a
+          class="user-card__location"
+          [href]="mapsUrl()"
+          target="_blank"
+          rel="noopener noreferrer"
+          [attr.aria-label]="'Ver ' + user().location + ' en Google Maps (nueva pestaña)'"
+        >
+          <svg class="user-card__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path
+              d="M12 2a7 7 0 0 0-7 7c0 5.25 7 13 7 13s7-7.75 7-13a7 7 0 0 0-7-7zm0 9.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5z"
+              fill="currentColor"
+            />
+          </svg>
+          <span>{{ user().location }}</span>
+        </a>
       </dd>
     </div>
     <div class="user-card__meta-row">

--- a/src/app/shared/ui/user-card/user-card.ts
+++ b/src/app/shared/ui/user-card/user-card.ts
@@ -2,10 +2,21 @@ import { ChangeDetectionStrategy, Component, computed, input, signal } from '@an
 import type { Role, User } from '@features/users/user';
 
 const ROLE_LABEL: Readonly<Record<Role, string>> = {
-  admin: 'Administrador',
+  admin: 'Admin',
   developer: 'Developer',
   designer: 'Designer',
 };
+
+interface AvatarTilt {
+  readonly x: number;
+  readonly y: number;
+  readonly scale: number;
+}
+
+const AVATAR_REST: AvatarTilt = { x: 0, y: 0, scale: 1 };
+const AVATAR_MAX_TILT_DEG = 18;
+const AVATAR_MAX_SCALE = 1.286;
+const AVATAR_MIN_SCALE = 1.104;
 
 @Component({
   selector: 'app-user-card',
@@ -17,6 +28,7 @@ export class UserCard {
   readonly user = input.required<User>();
 
   protected readonly avatarFailed = signal(false);
+  protected readonly tilt = signal<AvatarTilt>(AVATAR_REST);
 
   protected readonly initials = computed(() => {
     const parts = this.user().name.trim().split(/\s+/).filter(Boolean);
@@ -27,6 +39,11 @@ export class UserCard {
 
   protected readonly roleLabel = computed(() => ROLE_LABEL[this.user().role]);
 
+  protected readonly mapsUrl = computed(() => {
+    const query = encodeURIComponent(`${this.user().location}, Colombia`);
+    return `https://www.google.com/maps/search/?api=1&query=${query}`;
+  });
+
   protected readonly repoLabel = computed(() => {
     const n = this.user().repoIds.length;
     if (n === 0) return 'Sin repositorios';
@@ -36,5 +53,30 @@ export class UserCard {
 
   protected onAvatarError(): void {
     this.avatarFailed.set(true);
+  }
+
+  /**
+   * Calcula tilt + escala del avatar a partir de la posición del cursor:
+   * el avatar "mira" hacia donde apunta el cursor (rotateX/rotateY) y crece
+   * cuando el cursor se acerca al centro, encogiéndose hacia los bordes.
+   */
+  protected onAvatarMove(event: MouseEvent): void {
+    const stage = event.currentTarget as HTMLElement;
+    const rect = stage.getBoundingClientRect();
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
+    const nx = (event.clientX - cx) / (rect.width / 2);
+    const ny = (event.clientY - cy) / (rect.height / 2);
+    const dist = Math.min(1, Math.hypot(nx, ny));
+    const scale = AVATAR_MAX_SCALE - (AVATAR_MAX_SCALE - AVATAR_MIN_SCALE) * dist;
+    this.tilt.set({
+      x: -ny * AVATAR_MAX_TILT_DEG,
+      y: nx * AVATAR_MAX_TILT_DEG,
+      scale,
+    });
+  }
+
+  protected onAvatarLeave(): void {
+    this.tilt.set(AVATAR_REST);
   }
 }

--- a/src/app/shared/ui/user-card/user-card.ts
+++ b/src/app/shared/ui/user-card/user-card.ts
@@ -1,0 +1,40 @@
+import { ChangeDetectionStrategy, Component, computed, input, signal } from '@angular/core';
+import type { Role, User } from '@features/users/user';
+
+const ROLE_LABEL: Readonly<Record<Role, string>> = {
+  admin: 'Administrador',
+  developer: 'Developer',
+  designer: 'Designer',
+};
+
+@Component({
+  selector: 'app-user-card',
+  templateUrl: './user-card.html',
+  styleUrl: './user-card.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class UserCard {
+  readonly user = input.required<User>();
+
+  protected readonly avatarFailed = signal(false);
+
+  protected readonly initials = computed(() => {
+    const parts = this.user().name.trim().split(/\s+/).filter(Boolean);
+    const first = parts[0]?.[0] ?? '';
+    const last = parts.length > 1 ? (parts[parts.length - 1]?.[0] ?? '') : '';
+    return (first + last).toUpperCase() || '?';
+  });
+
+  protected readonly roleLabel = computed(() => ROLE_LABEL[this.user().role]);
+
+  protected readonly repoLabel = computed(() => {
+    const n = this.user().repoIds.length;
+    if (n === 0) return 'Sin repositorios';
+    if (n === 1) return '1 repositorio';
+    return `${String(n)} repositorios`;
+  });
+
+  protected onAvatarError(): void {
+    this.avatarFailed.set(true);
+  }
+}


### PR DESCRIPTION
## Summary
- Implementa el listado paginado de usuarios contra el JSON externo (30 usuarios) con `pageSize=6` y paginator con elipsis y modo compacto en móvil.
- Toolbar de filtros **reutilizable** (`FilterToolbar` shell + `SearchInputField`, `ChipsField<T>`, `SelectField<T>`) consumible luego por la página de Repositorios. La página cablea los 4 criterios de `UserFilters` (query, role, location, hasRepos) con signals + `toSignal/toObservable` (debounce 200 ms en el texto).
- `UserCard` con tilt 3D + escala dinámica del avatar según la posición del cursor, link a Google Maps en la ubicación (`_blank` + `rel="noopener noreferrer"`), email `mailto:`, fallback a iniciales si la imagen falla, chip de rol y badge de repos con estado vacío diferenciado.
- Layout: paginator anclado al borde inferior del viewport, grid centrada horizontalmente y top-aligned, cards edge-to-edge con el toolbar en desktop/tablet y full-width en móvil (1 columna).
- `docker-compose.dev.yml` (stage `development`) ya entregado en la iteración anterior — branch funcional con `docker compose -f docker-compose.dev.yml up`.

## Test plan
- [ ] `npm run typecheck`, `npm run lint`, `npx ng test --watch=false` (23 tests del dominio existente, todos pasan).
- [ ] `npm start` o `docker compose -f docker-compose.dev.yml up` y abrir `/usuarios`.
- [ ] Verificar 30 usuarios paginados a 5 páginas; navegar con paginator y observar el reset a la primera página al cambiar filtros.
- [ ] Probar combinaciones de filtros: texto + rol + ubicación + "Con/Sin repos"; verificar el contador "X de 30 coinciden" y el estado vacío con CTA "Limpiar filtros".
- [ ] Hover sobre los avatares → tilt 3D + escala que cambia con la trayectoria del cursor.
- [ ] Click en una ubicación → abre Google Maps en nueva pestaña con la ciudad + Colombia.
- [ ] Responsive: desktop 3 columnas edge-to-edge, tablet 2 columnas, móvil 1 columna full-width; toolbar y paginator también responsive.
- [ ] `prefers-reduced-motion: reduce` → animaciones de entrada y tilt del avatar deshabilitadas.