### PR TITLE
feat(repositories): listado de repositorios con filtros, paginación y cards interactivas

### DIFF
--- a/src/app/features/repositories/repositories-page.css
+++ b/src/app/features/repositories/repositories-page.css
@@ -1,44 +1,221 @@
 :host {
-  display: block;
+  /* Llena el viewport visible debajo del navbar para que el paginator
+     quede anclado al borde inferior y la grid se centre verticalmente. */
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100dvh - var(--layout-navbar-h, 4rem) - 4rem);
+
+  /* Estado inicial explícito → sin FOUC en SSR */
   opacity: 0;
   transform: translateY(16px);
   animation: pageEnter 600ms cubic-bezier(0.2, 0, 0, 1) forwards;
 }
 
-.repos-page__title,
-.repos-page__placeholder {
-  opacity: 0;
-  transform: translateY(14px);
-  animation: fadeUp 600ms cubic-bezier(0.2, 0, 0, 1) forwards;
-}
-.repos-page__title {
-  animation-delay: 100ms;
-}
-.repos-page__placeholder {
-  animation-delay: 220ms;
-}
-
 @media (prefers-reduced-motion: reduce) {
-  :host,
-  .repos-page__title,
-  .repos-page__placeholder {
+  :host {
     animation: none;
     opacity: 1;
     transform: none;
   }
 }
 
-.repos-page__title {
-  font-size: clamp(1.75rem, 1.2rem + 1.5vw, 2.5rem);
-  margin: 0 0 0.75rem;
+.repos-page {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
 }
 
-.repos-page__placeholder {
+.repos-page__toolbar {
+  margin: var(--space-4) 0 0;
+}
+
+.repos-page__main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  min-height: 0;
+  padding: clamp(2rem, 5vh, 4rem) 0 var(--space-6);
+}
+
+.repos-page__paginator {
+  margin-top: var(--space-2);
+  margin-bottom: calc(var(--space-3) * -1);
+  border-top: 1px solid var(--color-border);
+  padding-top: var(--space-3);
+}
+
+.repos-page__header {
+  margin-bottom: 0;
+}
+
+.repos-page__title {
+  font-size: clamp(1.75rem, 1.2rem + 1.5vw, 2.5rem);
+  margin: 0 0 0.5rem;
+}
+
+.repos-page__subtitle {
   margin: 0;
-  padding: 1rem 1.25rem;
+  color: var(--color-text-muted);
+  font-size: 0.9375rem;
+}
+
+.repos-page__empty {
+  margin: 0;
+  padding: var(--space-6);
   border: 1px dashed var(--color-border);
   border-radius: 0.5rem;
   background: var(--color-surface);
   color: var(--color-text-muted);
-  font-size: 0.9375rem;
+  text-align: center;
+}
+
+.repos-page__empty-action {
+  margin-top: var(--space-3);
+  padding: 0.5rem 1rem;
+  font: inherit;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text);
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease;
+}
+
+.repos-page__empty-action:hover {
+  background: var(--c-uniandes-color-neutro-30);
+  border-color: var(--c-uniandes-color-neutro-50);
+}
+
+.repos-page__empty-action:focus-visible {
+  outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
+  outline-offset: 2px;
+}
+
+/* ── Responsive grid ─────────────────────────────────────────────────── */
+.repos-grid {
+  /* CSS Grid con `auto-fill + 1fr` → todas las tracks comparten la misma
+     anchura, calculada por el grid según el viewport. Así una fila parcial
+     (2 ó 1 cards) usa los mismos tracks que la fila completa: las columnas
+     quedan alineadas verticalmente entre filas y las cards llenan el
+     ancho de la fila a cada breakpoint sin huecos a la derecha. */
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(18rem, 100%), 1fr));
+  gap: var(--space-8);
+}
+
+.repos-grid__item {
+  min-width: 0;
+  /* Animación escalonada de entrada */
+  opacity: 0;
+  transform: translateY(8px);
+  animation: fadeUp 420ms cubic-bezier(0.2, 0, 0, 1) forwards;
+}
+
+.repos-grid__item:nth-child(1) {
+  animation-delay: 40ms;
+}
+.repos-grid__item:nth-child(2) {
+  animation-delay: 80ms;
+}
+.repos-grid__item:nth-child(3) {
+  animation-delay: 120ms;
+}
+.repos-grid__item:nth-child(4) {
+  animation-delay: 160ms;
+}
+.repos-grid__item:nth-child(5) {
+  animation-delay: 200ms;
+}
+.repos-grid__item:nth-child(6) {
+  animation-delay: 240ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .repos-grid__item {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* ── Skeleton mientras carga ─────────────────────────────────────────── */
+.repo-skeleton {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-6);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 0.75rem;
+}
+
+.repo-skeleton__badge {
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 0.875rem;
+  background: var(--c-uniandes-color-neutro-30);
+  position: relative;
+  overflow: hidden;
+}
+
+.repo-skeleton__lines {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.repo-skeleton__line {
+  height: 0.75rem;
+  border-radius: 0.25rem;
+  background: var(--c-uniandes-color-neutro-30);
+  position: relative;
+  overflow: hidden;
+}
+
+.repo-skeleton__line--lg {
+  width: 70%;
+}
+.repo-skeleton__line--md {
+  width: 50%;
+}
+.repo-skeleton__line--sm {
+  width: 35%;
+}
+
+.repo-skeleton__badge::after,
+.repo-skeleton__line::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.6) 50%,
+    transparent 100%
+  );
+  transform: translateX(-100%);
+  animation: shimmer 1.4s infinite;
+}
+
+@keyframes shimmer {
+  to {
+    transform: translateX(100%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .repo-skeleton__badge::after,
+  .repo-skeleton__line::after {
+    animation: none;
+  }
 }

--- a/src/app/features/repositories/repositories-page.html
+++ b/src/app/features/repositories/repositories-page.html
@@ -1,6 +1,96 @@
-<section class="repos-page">
-  <h1 class="repos-page__title">{{ title }}</h1>
-  <p class="repos-page__placeholder">
-    Implementar componente para listar repositorios. HU pendiente de iteraciones posteriores.
-  </p>
+<section class="repos-page" aria-labelledby="repos-page-title">
+  <header class="repos-page__header">
+    <h1 id="repos-page-title" class="repos-page__title">{{ title }}</h1>
+    @if (!isLoading()) {
+      <p class="repos-page__subtitle" aria-live="polite">
+        @if (hasActiveFilters()) {
+          {{ total() }} de {{ grandTotal() }} repositorios coinciden
+        } @else {
+          {{ total() }} repositorios en la comunidad
+        }
+      </p>
+    }
+  </header>
+
+  <app-filter-toolbar
+    class="repos-page__toolbar"
+    ariaLabel="Filtros de repositorios"
+    [hasActive]="hasActiveFilters()"
+    (clear)="onReset()"
+  >
+    <app-search-input
+      ariaLabel="Buscar por nombre o descripción"
+      placeholder="Buscar por nombre o descripción…"
+      [value]="query()"
+      (valueChange)="query.set($event)"
+    />
+    <app-select-field
+      ariaLabel="Filtrar por lenguaje"
+      placeholder="Todos los lenguajes"
+      [options]="languageOptions()"
+      [value]="language()"
+      (valueChange)="language.set($event)"
+    />
+    <app-select-field
+      ariaLabel="Filtrar por propietario"
+      placeholder="Todos los propietarios"
+      [options]="ownerOptions()"
+      [value]="ownerIdStr()"
+      (valueChange)="ownerIdStr.set($event)"
+    />
+    <app-chips-field
+      ariaLabel="Filtrar por popularidad"
+      [options]="popularidadOptions"
+      [value]="popularidad()"
+      (valueChange)="popularidad.set($event)"
+    />
+  </app-filter-toolbar>
+
+  <div class="repos-page__main">
+    @if (isLoading()) {
+      <ul class="repos-grid" aria-label="Cargando repositorios" aria-busy="true">
+        @for (slot of skeletonSlots; track slot) {
+          <li class="repos-grid__item">
+            <div class="repo-skeleton" aria-hidden="true">
+              <div class="repo-skeleton__badge"></div>
+              <div class="repo-skeleton__lines">
+                <div class="repo-skeleton__line repo-skeleton__line--lg"></div>
+                <div class="repo-skeleton__line repo-skeleton__line--md"></div>
+                <div class="repo-skeleton__line repo-skeleton__line--sm"></div>
+              </div>
+            </div>
+          </li>
+        }
+      </ul>
+    } @else if (paged(); as pageEntries) {
+      @if (pageEntries.length === 0) {
+        <div class="repos-page__empty">
+          <p>No hay repositorios que coincidan con los filtros.</p>
+          @if (hasActiveFilters()) {
+            <button type="button" class="repos-page__empty-action" (click)="onReset()">
+              Limpiar filtros
+            </button>
+          }
+        </div>
+      } @else {
+        <ul class="repos-grid">
+          @for (entry of pageEntries; track entry.repo.id) {
+            <li class="repos-grid__item">
+              <app-repository-card [repository]="entry.repo" [owner]="entry.owner" />
+            </li>
+          }
+        </ul>
+      }
+    }
+  </div>
+
+  @if (!isLoading() && total() > pageSize) {
+    <app-paginator
+      class="repos-page__paginator"
+      [total]="total()"
+      [pageSize]="pageSize"
+      [page]="page()"
+      (pageChange)="onPageChange($event)"
+    />
+  }
 </section>

--- a/src/app/features/repositories/repositories-page.ts
+++ b/src/app/features/repositories/repositories-page.ts
@@ -144,7 +144,9 @@ export class RepositoriesPage {
   constructor() {
     effect(() => {
       this.filters();
-      untracked(() => { this.page.set(1); });
+      untracked(() => {
+        this.page.set(1);
+      });
     });
   }
 

--- a/src/app/features/repositories/repositories-page.ts
+++ b/src/app/features/repositories/repositories-page.ts
@@ -1,11 +1,164 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  signal,
+  untracked,
+} from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { debounceTime, distinctUntilChanged } from 'rxjs';
+
+import { RepositoryCard } from '@shared/ui/repository-card/repository-card';
+import { Paginator } from '@shared/ui/paginator/paginator';
+import {
+  type ChipOption,
+  ChipsField,
+  FilterToolbar,
+  SearchInputField,
+  type SelectOption,
+  SelectField,
+} from '@shared/ui/filter-toolbar';
+import { Users } from '@features/users';
+import type { User } from '@features/users/user';
+import { Repositories } from './repositories';
+import type { Repository, RepositoryFilters } from './repository';
+
+interface RepoEntry {
+  readonly repo: Repository;
+  readonly owner: User | null;
+}
+
+const POPULARITY_THRESHOLD = 100;
 
 @Component({
   selector: 'app-repositories-page',
+  imports: [RepositoryCard, Paginator, FilterToolbar, SearchInputField, ChipsField, SelectField],
   templateUrl: './repositories-page.html',
   styleUrl: './repositories-page.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RepositoriesPage {
+  private readonly reposService = inject(Repositories);
+  private readonly usersService = inject(Users);
+
   protected readonly title = 'Repositorios';
+  protected readonly pageSize = 6;
+
+  /* ── Estado de filtros ─────────────────────────────────────────────── */
+  protected readonly query = signal('');
+  protected readonly language = signal<string | null>(null);
+  protected readonly ownerIdStr = signal<string | null>(null);
+  protected readonly popularidad = signal<boolean | null>(null);
+  protected readonly page = signal(1);
+
+  protected readonly popularidadOptions: ReadonlyArray<ChipOption<boolean>> = [
+    { value: true, label: 'Populares' },
+    { value: false, label: 'Emergentes' },
+  ];
+
+  /* ── Datos ─────────────────────────────────────────────────────────── */
+  private readonly allRepos = toSignal(this.reposService.list(), { initialValue: undefined });
+  private readonly allUsers = toSignal(this.usersService.list(), { initialValue: undefined });
+
+  private readonly userById = computed<ReadonlyMap<number, User> | null>(() => {
+    const list = this.allUsers();
+    if (!list) return null;
+    const map = new Map<number, User>();
+    for (const u of list) map.set(u.id, u);
+    return map;
+  });
+
+  /* Debounce sólo del input de texto. */
+  private readonly debouncedQuery = toSignal(
+    toObservable(this.query).pipe(debounceTime(200), distinctUntilChanged()),
+    { initialValue: '' },
+  );
+
+  protected readonly filters = computed<RepositoryFilters>(() => {
+    const f: { -readonly [K in keyof RepositoryFilters]?: RepositoryFilters[K] } = {};
+    const q = this.debouncedQuery().trim();
+    if (q.length > 0) f.query = q;
+    const lang = this.language();
+    if (lang !== null) f.language = lang;
+    const oid = this.ownerIdStr();
+    if (oid !== null) f.ownerId = Number(oid);
+    const pop = this.popularidad();
+    if (pop === true) f.minStars = POPULARITY_THRESHOLD;
+    if (pop === false) f.maxStars = POPULARITY_THRESHOLD - 1;
+    return f;
+  });
+
+  protected readonly hasActiveFilters = computed(() => Object.keys(this.filters()).length > 0);
+
+  protected readonly filtered = computed(() => {
+    const list = this.allRepos();
+    if (!list) return undefined;
+    return list.filter((r) => r.matches(this.filters()));
+  });
+
+  /* Opciones de filtro derivadas del snapshot. */
+  protected readonly languageOptions = computed<ReadonlyArray<SelectOption<string>>>(() => {
+    const list = this.allRepos();
+    if (!list) return [];
+    const seen = new Set<string>();
+    for (const r of list) seen.add(r.language);
+    return Array.from(seen)
+      .sort((a, b) => a.localeCompare(b))
+      .map((lang) => ({ value: lang, label: lang }));
+  });
+
+  protected readonly ownerOptions = computed<ReadonlyArray<SelectOption<string>>>(() => {
+    const repos = this.allRepos();
+    const users = this.allUsers();
+    if (!repos || !users) return [];
+    const ownerIds = new Set<number>();
+    for (const r of repos) ownerIds.add(r.ownerId);
+    return Array.from(ownerIds)
+      .map((id) => users.find((u) => u.id === id))
+      .filter((u): u is User => u !== undefined)
+      .sort((a, b) => a.name.localeCompare(b.name, 'es'))
+      .map((u) => ({ value: String(u.id), label: u.name }));
+  });
+
+  protected readonly total = computed(() => this.filtered()?.length ?? 0);
+  protected readonly grandTotal = computed(() => this.allRepos()?.length ?? 0);
+  protected readonly isLoading = computed(
+    () => this.allRepos() === undefined || this.allUsers() === undefined,
+  );
+
+  protected readonly paged = computed<readonly RepoEntry[] | undefined>(() => {
+    const list = this.filtered();
+    if (!list) return undefined;
+    const map = this.userById();
+    const start = (this.page() - 1) * this.pageSize;
+    return list.slice(start, start + this.pageSize).map((repo) => ({
+      repo,
+      owner: map?.get(repo.ownerId) ?? null,
+    }));
+  });
+
+  protected readonly skeletonSlots = Array.from({ length: this.pageSize }, (_, i) => i);
+
+  constructor() {
+    effect(() => {
+      this.filters();
+      untracked(() => { this.page.set(1); });
+    });
+  }
+
+  protected onPageChange(page: number): void {
+    this.page.set(page);
+    if (typeof window !== 'undefined') {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  }
+
+  protected onReset(): void {
+    this.query.set('');
+    this.language.set(null);
+    this.ownerIdStr.set(null);
+    this.popularidad.set(null);
+  }
 }

--- a/src/app/features/users/users-page.css
+++ b/src/app/features/users/users-page.css
@@ -109,39 +109,25 @@
 
 /* ── Responsive grid ─────────────────────────────────────────────────── */
 .users-grid {
-  /* Flex con justify-content:center → las cards se centran horizontalmente
-     en cada fila aunque la última no quede llena (1 sola card también). */
+  /* CSS Grid con `auto-fill + 1fr` → todos los tracks comparten la misma
+     anchura, calculada por el grid según el viewport. Una fila parcial
+     (e.g. 2 cards en grid de 3 tracks) usa los mismos tracks que una fila
+     completa: las columnas quedan alineadas verticalmente y las cards
+     llenan el ancho disponible a cada breakpoint sin huecos a la derecha. */
   list-style: none;
   margin: 0;
   padding: 0;
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  align-content: flex-start;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(18rem, 100%), 1fr));
   gap: var(--space-8);
 }
 
 .users-grid__item {
-  /* `flex: 1 1 18rem` permite a las cards crecer y rellenar el ancho del
-     contenedor → cuando hay 3 cards en una fila, sus bordes coinciden con
-     los del toolbar. `max-width: 22rem` evita que una card sola se estire
-     demasiado en pantallas anchas. */
-  flex: 1 1 18rem;
-  max-width: 22rem;
   min-width: 0;
   /* Animación escalonada de entrada */
   opacity: 0;
   transform: translateY(8px);
   animation: fadeUp 420ms cubic-bezier(0.2, 0, 0, 1) forwards;
-}
-
-/* En viewports donde solo cabe 1 columna (≤ 608 px de contenedor), la card
-   se extiende al ancho completo para alinearse con los bordes laterales
-   del toolbar. */
-@media (max-width: 640px) {
-  .users-grid__item {
-    max-width: 100%;
-  }
 }
 
 .users-grid__item:nth-child(1) {

--- a/src/app/shared/ui/repository-card/repository-card.css
+++ b/src/app/shared/ui/repository-card/repository-card.css
@@ -1,0 +1,288 @@
+:host {
+  display: block;
+  height: 100%;
+}
+
+.repo-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  height: 100%;
+  padding: var(--space-6);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 0.75rem;
+  box-shadow: 0 1px 2px rgba(25, 25, 22, 0.04);
+  transition:
+    transform 220ms cubic-bezier(0.2, 0, 0, 1),
+    box-shadow 220ms cubic-bezier(0.2, 0, 0, 1),
+    border-color 220ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+.repo-card:hover,
+.repo-card:focus-within {
+  transform: translateY(-2px);
+  border-color: var(--c-uniandes-color-neutro-50);
+  box-shadow: 0 6px 18px rgba(25, 25, 22, 0.08);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .repo-card,
+  .repo-card__badge {
+    transition: none;
+  }
+  .repo-card:hover,
+  .repo-card:focus-within {
+    transform: none;
+  }
+  .repo-card__badge {
+    transform: none !important;
+  }
+}
+
+/* ── Header ──────────────────────────────────────────────────────────── */
+.repo-card__header {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.repo-card__badge-stage {
+  width: 3.5rem;
+  height: 3.5rem;
+  flex-shrink: 0;
+  perspective: 600px;
+}
+
+.repo-card__badge {
+  display: grid;
+  place-items: center;
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 0.875rem;
+  color: #fff;
+  border: 2px solid var(--color-bg);
+  box-shadow: 0 0 0 1px var(--color-border);
+  transform-origin: center;
+  transition: transform 160ms cubic-bezier(0.2, 0, 0, 1);
+  will-change: transform;
+}
+
+.repo-card__badge svg {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+.repo-card__identity {
+  min-width: 0;
+}
+
+.repo-card__name {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+  color: var(--color-text);
+  width: fit-content;
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.repo-card:hover .repo-card__name,
+.repo-card:focus-within .repo-card__name {
+  background-image: linear-gradient(
+    var(--c-uniandes-color-secondary-01-lightbg),
+    var(--c-uniandes-color-secondary-01-lightbg)
+  );
+  background-repeat: no-repeat;
+  background-position: 0 88%;
+  background-size: 100% 0.35em;
+}
+
+.repo-card__description {
+  margin: 0.25rem 0 0;
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+  /* 2 líneas como máximo, ellipsis al final. */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  overflow: hidden;
+}
+
+/* ── Language chip ───────────────────────────────────────────────────── */
+.repo-card__lang {
+  align-self: start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  background: var(--c-uniandes-color-neutro-30);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  white-space: nowrap;
+}
+
+.repo-card__lang-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+/* ── Meta (owner + created) ──────────────────────────────────────────── */
+.repo-card__meta {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  font-size: 0.875rem;
+}
+
+.repo-card__meta-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.repo-card__meta-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.repo-card__meta-value {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  color: var(--color-text-muted);
+}
+
+.repo-card__meta-value > span,
+.repo-card__meta-value time {
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.repo-card__owner-avatar {
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+  background: var(--c-uniandes-color-neutro-30);
+}
+
+.repo-card__owner-avatar--initials {
+  display: grid;
+  place-items: center;
+  font-size: 0.625rem;
+  font-weight: 600;
+  color: var(--color-text);
+  background: var(--c-uniandes-color-secondary-02-lightbg);
+}
+
+.repo-card__owner-unknown {
+  font-style: italic;
+  color: var(--color-text-disabled);
+}
+
+.repo-card__icon {
+  flex-shrink: 0;
+  width: 1rem;
+  height: 1rem;
+  color: var(--c-uniandes-color-neutro-70);
+}
+
+/* ── Footer (stars badge) ────────────────────────────────────────────── */
+.repo-card__footer {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--color-border);
+}
+
+.repo-card__stars {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  padding: 0.25rem 0.625rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  transition:
+    background-color 200ms ease,
+    border-color 200ms ease,
+    color 200ms ease;
+}
+
+/* ── Tiers de popularidad (alineados con la distribución 15–140 del JSON) ─
+   low   <  40 → neutro (frío)
+   mid   40–79 → azul tenue (en crecimiento)
+   high  80–119 → verde (consolidado)
+   top   ≥ 120 → dorado/alerta (top del ranking) */
+.repo-card__stars--low {
+  background: var(--c-uniandes-color-neutro-30);
+  color: var(--color-text);
+  border-color: var(--color-border);
+}
+.repo-card__stars--low .repo-card__icon {
+  color: var(--c-uniandes-color-neutro-60);
+}
+
+.repo-card__stars--mid {
+  background: rgba(36, 66, 178, 0.08);
+  color: var(--color-accent);
+  border-color: rgba(36, 66, 178, 0.25);
+}
+.repo-card__stars--mid .repo-card__icon {
+  color: var(--color-accent);
+}
+
+.repo-card__stars--high {
+  background: rgba(11, 115, 16, 0.1);
+  color: var(--c-uniandes-color-success-lightbg);
+  border-color: rgba(11, 115, 16, 0.3);
+}
+.repo-card__stars--high .repo-card__icon {
+  color: var(--c-uniandes-color-success-lightbg);
+}
+
+.repo-card__stars--top {
+  background: var(--c-uniandes-color-secondary-02-lightbg);
+  color: var(--c-uniandes-color-primarytext-lightbg);
+  border-color: var(--c-uniandes-color-secondary-01-lightbg);
+}
+.repo-card__stars--top .repo-card__icon {
+  color: var(--c-uniandes-color-alert-lightbg);
+}
+
+/* Focus visibility */
+.repo-card a:focus-visible,
+.repo-card button:focus-visible {
+  outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
+  outline-offset: 3px;
+  border-radius: 0.25rem;
+}

--- a/src/app/shared/ui/repository-card/repository-card.html
+++ b/src/app/shared/ui/repository-card/repository-card.html
@@ -1,0 +1,95 @@
+<article class="repo-card" [attr.aria-labelledby]="'repo-' + repository().id + '-name'">
+  <header class="repo-card__header">
+    <div
+      class="repo-card__badge-stage"
+      (mousemove)="onBadgeMove($event)"
+      (mouseleave)="onBadgeLeave()"
+    >
+      <div
+        class="repo-card__badge"
+        [style.background-color]="languageColor()"
+        [style.transform]="
+          'rotateX(' + tilt().x + 'deg) rotateY(' + tilt().y + 'deg) scale(' + tilt().scale + ')'
+        "
+        aria-hidden="true"
+      >
+        <svg viewBox="0 0 24 24" focusable="false">
+          <path
+            d="M9.4 16.6 4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0L19.2 12l-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"
+            fill="currentColor"
+          />
+        </svg>
+      </div>
+    </div>
+    <div class="repo-card__identity">
+      <h3 [id]="'repo-' + repository().id + '-name'" class="repo-card__name">
+        {{ repository().name }}
+      </h3>
+      <p class="repo-card__description">{{ repository().description }}</p>
+    </div>
+    <span class="repo-card__lang" [attr.aria-label]="'Lenguaje: ' + repository().language">
+      <span
+        class="repo-card__lang-dot"
+        [style.background-color]="languageColor()"
+        aria-hidden="true"
+      ></span>
+      {{ repository().language }}
+    </span>
+  </header>
+
+  <dl class="repo-card__meta">
+    <div class="repo-card__meta-row">
+      <dt class="repo-card__meta-label">Propietario</dt>
+      <dd class="repo-card__meta-value">
+        @if (owner(); as o) {
+          @if (avatarFailed()) {
+            <span
+              class="repo-card__owner-avatar repo-card__owner-avatar--initials"
+              aria-hidden="true"
+            >
+              {{ ownerInitials() }}
+            </span>
+          } @else {
+            <img
+              class="repo-card__owner-avatar"
+              [src]="o.avatarUrl"
+              [alt]="'Avatar de ' + o.name"
+              width="20"
+              height="20"
+              loading="lazy"
+              decoding="async"
+              (error)="onOwnerAvatarError()"
+            />
+          }
+          <span>{{ o.name }}</span>
+        } @else {
+          <span class="repo-card__owner-unknown">Propietario desconocido</span>
+        }
+      </dd>
+    </div>
+    <div class="repo-card__meta-row">
+      <dt class="repo-card__meta-label">Creado</dt>
+      <dd class="repo-card__meta-value">
+        <svg class="repo-card__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            d="M7 2a1 1 0 0 1 1 1v1h8V3a1 1 0 1 1 2 0v1h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2V3a1 1 0 0 1 1-1zm13 8H4v10h16V10zM4 8h16V6h-2v1a1 1 0 1 1-2 0V6H8v1a1 1 0 1 1-2 0V6H4v2z"
+            fill="currentColor"
+          />
+        </svg>
+        <time [attr.datetime]="repository().createdAt">{{ createdAtLabel() }}</time>
+      </dd>
+    </div>
+  </dl>
+
+  <footer class="repo-card__footer">
+    <span class="repo-card__stars repo-card__stars--{{ starsTier() }}">
+      <svg class="repo-card__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path
+          d="M12 2.5l2.95 5.97 6.59.96-4.77 4.65 1.13 6.56L12 17.55l-5.9 3.09 1.13-6.56-4.77-4.65 6.59-.96L12 2.5z"
+          fill="currentColor"
+        />
+      </svg>
+      {{ starsLabel() }}
+    </span>
+  </footer>
+</article>

--- a/src/app/shared/ui/repository-card/repository-card.ts
+++ b/src/app/shared/ui/repository-card/repository-card.ts
@@ -1,0 +1,122 @@
+import { ChangeDetectionStrategy, Component, computed, input, signal } from '@angular/core';
+import type { Repository } from '@features/repositories/repository';
+import type { User } from '@features/users/user';
+
+/**
+ * Paleta canónica de colores de lenguaje (estilo GitHub linguist) usada para
+ * teñir el badge de identidad y el dot del chip.
+ */
+const LANGUAGE_COLOR: Readonly<Record<string, string>> = {
+  TypeScript: '#3178c6',
+  JavaScript: '#f1e05a',
+  Python: '#3572a5',
+  Java: '#b07219',
+  Go: '#00add8',
+  Rust: '#dea584',
+  'C#': '#178600',
+  'C++': '#f34b7d',
+  Ruby: '#701516',
+  Swift: '#f05138',
+  Kotlin: '#a97bff',
+  HTML: '#e34c26',
+  CSS: '#563d7c',
+  Shell: '#89e051',
+  YAML: '#cb171e',
+};
+
+const FALLBACK_LANGUAGE_COLOR = '#73726d';
+
+const DATE_FORMATTER = new Intl.DateTimeFormat('es-CO', {
+  day: 'numeric',
+  month: 'long',
+  year: 'numeric',
+});
+
+interface BadgeTilt {
+  readonly x: number;
+  readonly y: number;
+  readonly scale: number;
+}
+
+const BADGE_REST: BadgeTilt = { x: 0, y: 0, scale: 1 };
+const BADGE_MAX_TILT_DEG = 18;
+const BADGE_MAX_SCALE = 1.286;
+const BADGE_MIN_SCALE = 1.104;
+
+@Component({
+  selector: 'app-repository-card',
+  templateUrl: './repository-card.html',
+  styleUrl: './repository-card.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RepositoryCard {
+  readonly repository = input.required<Repository>();
+  readonly owner = input<User | null>(null);
+
+  protected readonly avatarFailed = signal(false);
+  protected readonly tilt = signal<BadgeTilt>(BADGE_REST);
+
+  protected readonly languageColor = computed(
+    () => LANGUAGE_COLOR[this.repository().language] ?? FALLBACK_LANGUAGE_COLOR,
+  );
+
+  protected readonly createdAtLabel = computed(() =>
+    DATE_FORMATTER.format(this.repository().createdAtDate),
+  );
+
+  protected readonly starsLabel = computed(() => {
+    const n = this.repository().stars;
+    if (n === 1) return '1 estrellita';
+    return `${String(n)} estrellitas`;
+  });
+
+  /**
+   * Tier de popularidad para colorear el badge de estrellas. Los umbrales
+   * están alineados con la distribución del dataset (15–140, media 66).
+   */
+  protected readonly starsTier = computed<'low' | 'mid' | 'high' | 'top'>(() => {
+    const n = this.repository().stars;
+    if (n >= 120) return 'top';
+    if (n >= 80) return 'high';
+    if (n >= 40) return 'mid';
+    return 'low';
+  });
+
+  protected readonly ownerInitials = computed(() => {
+    const o = this.owner();
+    if (!o) return '?';
+    const parts = o.name.trim().split(/\s+/).filter(Boolean);
+    const first = parts[0]?.[0] ?? '';
+    const last = parts.length > 1 ? (parts[parts.length - 1]?.[0] ?? '') : '';
+    return (first + last).toUpperCase() || '?';
+  });
+
+  protected onOwnerAvatarError(): void {
+    this.avatarFailed.set(true);
+  }
+
+  /**
+   * Tilt 3D + escala dinámica del badge de lenguaje, en paralelo al efecto
+   * del avatar de UserCard: el badge "mira" hacia donde apunta el cursor y
+   * crece más cuando el cursor pasa por el centro.
+   */
+  protected onBadgeMove(event: MouseEvent): void {
+    const stage = event.currentTarget as HTMLElement;
+    const rect = stage.getBoundingClientRect();
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
+    const nx = (event.clientX - cx) / (rect.width / 2);
+    const ny = (event.clientY - cy) / (rect.height / 2);
+    const dist = Math.min(1, Math.hypot(nx, ny));
+    const scale = BADGE_MAX_SCALE - (BADGE_MAX_SCALE - BADGE_MIN_SCALE) * dist;
+    this.tilt.set({
+      x: -ny * BADGE_MAX_TILT_DEG,
+      y: nx * BADGE_MAX_TILT_DEG,
+      scale,
+    });
+  }
+
+  protected onBadgeLeave(): void {
+    this.tilt.set(BADGE_REST);
+  }
+}


### PR DESCRIPTION
## Summary
Implementa la HU "Listado de Repositorios" siguiendo el estilo de la HU de Usuarios, reutilizando los componentes compartidos del toolbar y adaptando lo necesario para el dominio.

### Componentes
- **`RepositoryCard`** (nuevo, en `src/app/shared/ui/repository-card`): badge de identidad con color de lenguaje (paleta GitHub linguist) y efecto 3D tilt + escala dinámica según posición del cursor, nombre + descripción (line-clamp a 2 líneas), chip de lenguaje con dot, avatar mini del propietario con fallback a iniciales, fecha de creación en `es-CO` (`Intl.DateTimeFormat`), y badge de **estrellitas** con 4 tiers cromáticos:
  - `low` (< 40) → neutro
  - `mid` (40-79) → azul
  - `high` (80-119) → verde
  - `top` (≥ 120) → dorado / alerta
- **`RepositoriesPage`** (modificado): cablea 4 filtros con signals (`query`, `language`, `ownerId`, `popularidad`) → `RepositoryFilters`, combina los streams de `Users.list()` + `Repositories.list()` para resolver el propietario por `ownerId`, debounce 200 ms en el search, reset a la página 1 al cambiar filtros (`effect` + `untracked`).
- **`FilterToolbar` y átomos** (sin cambios): `SearchInputField`, `ChipsField<T>`, `SelectField<T>` reutilizados tal cual desde la feature de Usuarios. Validamos que el shell funciona como wireframe genérico.

### Layout
- Migración de `users-grid` y `repos-grid` de **flex + max-width** a **CSS Grid `repeat(auto-fill, minmax(min(18rem, 100%), 1fr))`**: las tracks se calculan por viewport y las cards comparten ancho idéntico entre filas. Filas parciales dejan tracks vacíos a la derecha en vez de inflar las cards (corrige el bug donde 2 cards en una fila aparecían más grandes que 3 cards en otra).
- Comportamiento responsive: 3 columnas ≥ 1024 px → 2 columnas 768-1023 px → 1 columna < 768 px (full-width).
- Paginator anclado al fondo del viewport (idéntico a usuarios).

## Test plan
- [ ] `npm run typecheck`, `npm run lint`, `npx ng test --watch=false` (23/23 tests del dominio existentes pasan).
- [ ] `docker compose -f docker-compose.dev.yml up` y abrir `/repositorios`.
- [ ] 30 repos paginados a 5 páginas (`pageSize=6`); paginador con elipsis y modo compacto en móvil.
- [ ] Combinar filtros: texto + lenguaje + propietario + Populares/Emergentes; verificar contador "X de 30 repositorios coinciden" y estado vacío con CTA "Limpiar filtros".
- [ ] Hover sobre los badges de lenguaje → tilt 3D + escala dinámica.
- [ ] Validar que las cards llenan la fila edge-to-edge en desktop y mantienen ancho idéntico entre filas parciales y completas.
- [ ] Probar la página de Usuarios (`/usuarios`) — el cambio del grid también aplicó allí; las cards deben llenar igual el ancho disponible.
- [ ] `prefers-reduced-motion: reduce` → tilt y animaciones de entrada deshabilitadas.

## Commits
- `ed23c10` — `feat(repositories): paginated repository listing with shared filter toolbar`