### PR TITLE
feat(users): vista de detalle de usuario + deep linking entre listados

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -3,7 +3,13 @@ import {
   ErrorHandler,
   provideBrowserGlobalErrorListeners,
 } from '@angular/core';
-import { PreloadAllModules, provideRouter, TitleStrategy, withPreloading } from '@angular/router';
+import {
+  PreloadAllModules,
+  provideRouter,
+  TitleStrategy,
+  withComponentInputBinding,
+  withPreloading,
+} from '@angular/router';
 import { provideHttpClient, withFetch, withInterceptorsFromDi } from '@angular/common/http';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
 
@@ -14,7 +20,7 @@ import { AppTitleStrategy } from './core/providers/app-title-strategy';
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
-    provideRouter(routes, withPreloading(PreloadAllModules)),
+    provideRouter(routes, withPreloading(PreloadAllModules), withComponentInputBinding()),
     provideHttpClient(withFetch(), withInterceptorsFromDi()),
     provideClientHydration(withEventReplay()),
     { provide: ErrorHandler, useClass: GlobalErrorHandler },

--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -1,4 +1,5 @@
 import { RenderMode, type ServerRoute } from '@angular/ssr';
+import { environment } from '@env/environment';
 
 /**
  * Prerender para todas las rutas → genera HTML estático en build time.
@@ -8,8 +9,24 @@ import { RenderMode, type ServerRoute } from '@angular/ssr';
  * Las llamadas HttpClient (`Users.list()`, `Repositories.list()`) se
  * ejecutan durante el prerender; los datos se embeben en el HTML vía
  * TransferState — el navegador hidrata sin volver a fetchear.
+ *
+ * Para rutas dinámicas (`:id`) Angular SSR exige `getPrerenderParams`
+ * que devuelva la lista de valores a materializar — fetcheamos el JSON
+ * de usuarios para enumerar todos los ids.
  */
 export const serverRoutes: ServerRoute[] = [
+  {
+    path: 'usuarios/:id',
+    renderMode: RenderMode.Prerender,
+    getPrerenderParams: async () => {
+      const response = await fetch(environment.apis.users);
+      if (!response.ok) {
+        throw new Error('Failed to fetch users for prerender: HTTP ' + String(response.status));
+      }
+      const users = (await response.json()) as ReadonlyArray<{ id: number }>;
+      return users.map((u) => ({ id: String(u.id) }));
+    },
+  },
   {
     path: '**',
     renderMode: RenderMode.Prerender,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -26,6 +26,16 @@ export const routes: Routes = [
         },
       },
       {
+        path: 'usuarios/:id',
+        loadComponent: () =>
+          import('./features/users/user-detail-page').then((m) => m.UserDetailPage),
+        title: 'Detalle de usuario',
+        data: {
+          description:
+            'Perfil detallado de un developer GhQuerry: información de contacto, repositorios mantenidos y comunidad relacionada.',
+        },
+      },
+      {
         path: 'repositorios',
         loadComponent: () =>
           import('./features/repositories/repositories-page').then((m) => m.RepositoriesPage),

--- a/src/app/features/repositories/repositories-page.ts
+++ b/src/app/features/repositories/repositories-page.ts
@@ -8,6 +8,7 @@ import {
   untracked,
 } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute } from '@angular/router';
 import { debounceTime, distinctUntilChanged } from 'rxjs';
 
 import { RepositoryCard } from '@shared/ui/repository-card/repository-card';
@@ -42,9 +43,24 @@ const POPULARITY_THRESHOLD = 100;
 export class RepositoriesPage {
   private readonly reposService = inject(Repositories);
   private readonly usersService = inject(Users);
+  private readonly route = inject(ActivatedRoute);
 
   protected readonly title = 'Repositorios';
   protected readonly pageSize = 6;
+
+  /**
+   * Query param `?owner=:id` leído reactivamente desde `ActivatedRoute`.
+   * Cuando se entra desde el badge de repositorios de un `UserCard`,
+   * pre-aplica el filtro de propietario.
+   */
+  private readonly ownerFromUrl = toSignal(
+    this.route.queryParamMap
+      .pipe
+      // Map a string | null para comparar/asignar fácilmente.
+      // (queryParamMap.get devuelve null cuando no existe).
+      (),
+    { initialValue: this.route.snapshot.queryParamMap },
+  );
 
   /* ── Estado de filtros ─────────────────────────────────────────────── */
   protected readonly query = signal('');
@@ -110,14 +126,13 @@ export class RepositoriesPage {
   });
 
   protected readonly ownerOptions = computed<ReadonlyArray<SelectOption<string>>>(() => {
-    const repos = this.allRepos();
     const users = this.allUsers();
-    if (!repos || !users) return [];
-    const ownerIds = new Set<number>();
-    for (const r of repos) ownerIds.add(r.ownerId);
-    return Array.from(ownerIds)
-      .map((id) => users.find((u) => u.id === id))
-      .filter((u): u is User => u !== undefined)
+    if (!users) return [];
+    /* Incluimos a TODOS los usuarios — incluso los que no mantienen
+       repositorios — para que el filtro pueda seleccionarlos (entrada
+       desde el badge "Sin repositorios" del UserCard) y el SelectField
+       muestre el label correcto. */
+    return [...users]
       .sort((a, b) => a.name.localeCompare(b.name, 'es'))
       .map((u) => ({ value: String(u.id), label: u.name }));
   });
@@ -142,6 +157,20 @@ export class RepositoriesPage {
   protected readonly skeletonSlots = Array.from({ length: this.pageSize }, (_, i) => i);
 
   constructor() {
+    /* Cuando se entra desde un UserCard con `?owner=:id`, sincroniza el
+       query param al filtro interno. `untracked` para no crear un loop
+       cuando el efecto siguiente lee el filtro derivado. */
+    effect(() => {
+      const fromUrl = this.ownerFromUrl().get('owner');
+      if (fromUrl !== null) {
+        const current = untracked(() => this.ownerIdStr());
+        if (current !== fromUrl) {
+          this.ownerIdStr.set(fromUrl);
+        }
+      }
+    });
+
+    /* Cualquier cambio en filtros nos devuelve a la página 1. */
     effect(() => {
       this.filters();
       untracked(() => {

--- a/src/app/features/users/user-detail-page.css
+++ b/src/app/features/users/user-detail-page.css
@@ -1,0 +1,606 @@
+:host {
+  display: block;
+  /* Estado inicial explícito → sin FOUC en SSR */
+  opacity: 0;
+  transform: translateY(16px);
+  animation: pageEnter 600ms cubic-bezier(0.2, 0, 0, 1) forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :host {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.user-detail {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+}
+
+/* ── Back link ───────────────────────────────────────────────────────── */
+.user-detail__back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  width: fit-content;
+  padding: 0.375rem 0.75rem 0.375rem 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  text-decoration: none;
+  transition:
+    color 160ms ease,
+    border-color 160ms ease,
+    background-color 160ms ease,
+    transform 160ms ease;
+}
+
+.user-detail__back:hover {
+  color: var(--color-text);
+  border-color: var(--c-uniandes-color-neutro-50);
+  background: var(--color-surface);
+  transform: translateX(-2px);
+}
+
+.user-detail__back:focus-visible {
+  outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
+  outline-offset: 2px;
+}
+
+.user-detail__back svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .user-detail__back {
+    transition: none;
+  }
+  .user-detail__back:hover {
+    transform: none;
+  }
+}
+
+/* ── Hero ────────────────────────────────────────────────────────────── */
+.user-detail__hero {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  align-items: center;
+  padding: clamp(1.5rem, 3vw, 2rem);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 1rem;
+  box-shadow: 0 1px 2px rgba(25, 25, 22, 0.04);
+}
+
+@media (max-width: 640px) {
+  .user-detail__hero {
+    grid-template-columns: 1fr;
+    text-align: center;
+    justify-items: center;
+  }
+}
+
+.user-detail__avatar-stage {
+  width: clamp(7rem, 14vw, 10rem);
+  height: clamp(7rem, 14vw, 10rem);
+  flex-shrink: 0;
+  perspective: 800px;
+}
+
+.user-detail__avatar {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
+  background: var(--c-uniandes-color-neutro-30);
+  border: 4px solid var(--color-bg);
+  box-shadow:
+    0 0 0 1px var(--color-border),
+    0 8px 24px rgba(25, 25, 22, 0.12);
+  transform-origin: center;
+  transition: transform 160ms cubic-bezier(0.2, 0, 0, 1);
+  will-change: transform;
+}
+
+.user-detail__avatar--initials {
+  display: grid;
+  place-items: center;
+  font-size: clamp(2rem, 4.5vw, 3rem);
+  font-weight: 700;
+  color: var(--c-uniandes-color-primarytext-lightbg);
+  background: var(--c-uniandes-color-secondary-02-lightbg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .user-detail__avatar {
+    transition: none;
+    transform: none !important;
+  }
+}
+
+.user-detail__identity {
+  min-width: 0;
+}
+
+.user-detail__eyebrow {
+  margin: 0;
+}
+
+.user-detail__role {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.3125rem 0.625rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.user-detail__role--admin {
+  background: var(--c-uniandes-color-secondary-02-lightbg);
+  color: var(--c-uniandes-color-primarytext-lightbg);
+  border-color: var(--c-uniandes-color-secondary-01-lightbg);
+}
+
+.user-detail__role--developer {
+  background: var(--c-uniandes-color-neutro-30);
+  color: var(--c-uniandes-color-primarytext-lightbg);
+  border-color: var(--color-border);
+}
+
+.user-detail__role--designer {
+  background: rgba(36, 66, 178, 0.08);
+  color: var(--color-accent);
+  border-color: rgba(36, 66, 178, 0.25);
+}
+
+.user-detail__name {
+  font-size: clamp(2rem, 5vw, 3rem);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  line-height: 1.1;
+  margin: 0.5rem 0 0.25rem;
+  color: var(--color-text);
+  /* Franja amarilla Uniandes bajo el nombre — destaca como título focal
+     de la página de detalle. `width: fit-content` ajusta la franja al
+     ancho del texto en lugar de extenderla a todo el contenedor. */
+  width: fit-content;
+  max-width: 100%;
+  background-image: linear-gradient(
+    var(--c-uniandes-color-secondary-01-lightbg),
+    var(--c-uniandes-color-secondary-01-lightbg)
+  );
+  background-repeat: no-repeat;
+  background-position: 0 92%;
+  background-size: 100% 0.35em;
+}
+
+@media (max-width: 640px) {
+  .user-detail__name {
+    margin-inline: auto;
+  }
+}
+
+.user-detail__username {
+  margin: 0;
+  font-size: clamp(0.9375rem, 1.5vw, 1.0625rem);
+  color: var(--color-text-muted);
+  font-feature-settings: 'tnum' 1;
+}
+
+/* ── Meta inline ─────────────────────────────────────────────────────── */
+.user-detail__meta {
+  list-style: none;
+  padding: 0;
+  margin: var(--space-4) 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-4);
+  font-size: 0.9375rem;
+  color: var(--color-text-muted);
+}
+
+.user-detail__meta-item {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  min-width: 0;
+}
+
+.user-detail__meta-item svg {
+  width: 1rem;
+  height: 1rem;
+  color: var(--c-uniandes-color-neutro-70);
+  flex-shrink: 0;
+}
+
+.user-detail__meta-item a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  color: inherit;
+  text-decoration: none;
+  border-radius: 0.25rem;
+  transition: color 160ms ease;
+}
+
+.user-detail__meta-item a:hover {
+  color: var(--color-text);
+}
+
+.user-detail__meta-item a:hover span {
+  text-decoration: underline;
+}
+
+.user-detail__meta-item a:focus-visible {
+  outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
+  outline-offset: 2px;
+}
+
+.user-detail__meta-item--static {
+  color: var(--color-text-muted);
+}
+
+@media (max-width: 640px) {
+  .user-detail__meta {
+    justify-content: center;
+  }
+}
+
+/* ── Section blocks (repos + others) ─────────────────────────────────── */
+.user-detail__section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.user-detail__section-title {
+  font-size: clamp(1.25rem, 2vw, 1.5rem);
+  font-weight: 600;
+  margin: 0;
+  color: var(--color-text);
+}
+
+.user-detail__empty {
+  margin: 0;
+  padding: var(--space-6);
+  border: 1px dashed var(--color-border);
+  border-radius: 0.5rem;
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+  text-align: center;
+  font-size: 0.9375rem;
+}
+
+/* ── Repos grid (mismo CSS Grid uniforme que las otras páginas) ──────── */
+.user-detail__repos-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(18rem, 100%), 1fr));
+  gap: var(--space-6);
+}
+
+.user-detail__repos-item {
+  min-width: 0;
+  opacity: 0;
+  transform: translateY(8px);
+  animation: fadeUp 420ms cubic-bezier(0.2, 0, 0, 1) forwards;
+}
+
+.user-detail__repos-item:nth-child(1) {
+  animation-delay: 60ms;
+}
+.user-detail__repos-item:nth-child(2) {
+  animation-delay: 120ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .user-detail__repos-item {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* ── Rail horizontal de "otros usuarios" ─────────────────────────────── */
+.user-detail__rail-wrapper {
+  position: relative;
+}
+
+.user-detail__rail {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: var(--space-4);
+  overflow-x: auto;
+  scroll-behavior: smooth;
+  scroll-snap-type: x proximity;
+  /* Scrollbar nativa oculta — la navegación del rail se hace con las
+     flechas. Mantenemos overflow auto para conservar swipe táctil y
+     scroll-wheel horizontal. */
+  scrollbar-width: none;
+}
+
+.user-detail__rail::-webkit-scrollbar {
+  display: none;
+}
+
+/* ── Flechas de control ──────────────────────────────────────────────── */
+.user-detail__rail-arrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 2;
+  display: inline-grid;
+  place-items: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  background: var(--color-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: 50%;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(25, 25, 22, 0.1);
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease,
+    opacity 200ms ease,
+    transform 160ms ease;
+}
+
+.user-detail__rail-arrow:hover:not(:disabled) {
+  background: var(--c-uniandes-color-secondary-01-lightbg);
+  border-color: var(--c-uniandes-color-secondary-01-lightbg);
+  color: var(--c-uniandes-color-primarytext-lightbg);
+  transform: translateY(-50%) scale(1.06);
+}
+
+.user-detail__rail-arrow:focus-visible {
+  outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
+  outline-offset: 2px;
+}
+
+.user-detail__rail-arrow:disabled {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.user-detail__rail-arrow svg {
+  width: 1.125rem;
+  height: 1.125rem;
+}
+
+.user-detail__rail-arrow--prev {
+  left: -0.5rem;
+}
+
+.user-detail__rail-arrow--next {
+  right: -0.5rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .user-detail__rail {
+    scroll-behavior: auto;
+  }
+  .user-detail__rail-arrow {
+    transition: none;
+  }
+  .user-detail__rail-arrow:hover:not(:disabled) {
+    transform: translateY(-50%);
+  }
+}
+
+.user-detail__rail-item {
+  scroll-snap-align: start;
+  flex-shrink: 0;
+}
+
+.other-user {
+  display: grid;
+  grid-template-rows: auto auto auto;
+  gap: 0.375rem;
+  width: 11rem;
+  padding: var(--space-4);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 0.75rem;
+  text-decoration: none;
+  color: inherit;
+  text-align: center;
+  justify-items: center;
+  transition:
+    transform 220ms cubic-bezier(0.2, 0, 0, 1),
+    border-color 220ms cubic-bezier(0.2, 0, 0, 1),
+    box-shadow 220ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+.other-user:hover {
+  transform: translateY(-2px);
+  border-color: var(--c-uniandes-color-neutro-50);
+  box-shadow: 0 6px 18px rgba(25, 25, 22, 0.08);
+}
+
+.other-user:focus-visible {
+  outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .other-user {
+    transition: none;
+  }
+  .other-user:hover {
+    transform: none;
+  }
+}
+
+.other-user__avatar {
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 50%;
+  object-fit: cover;
+  background: var(--c-uniandes-color-neutro-30);
+  border: 2px solid var(--color-bg);
+  box-shadow: 0 0 0 1px var(--color-border);
+}
+
+.other-user__name {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.other-user__role {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.125rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.other-user__role--admin {
+  background: var(--c-uniandes-color-secondary-02-lightbg);
+  color: var(--c-uniandes-color-primarytext-lightbg);
+  border-color: var(--c-uniandes-color-secondary-01-lightbg);
+}
+
+.other-user__role--developer {
+  background: var(--c-uniandes-color-neutro-30);
+  color: var(--c-uniandes-color-primarytext-lightbg);
+  border-color: var(--color-border);
+}
+
+.other-user__role--designer {
+  background: rgba(36, 66, 178, 0.08);
+  color: var(--color-accent);
+  border-color: rgba(36, 66, 178, 0.25);
+}
+
+/* ── Skeleton del hero ───────────────────────────────────────────────── */
+.user-detail__hero--skeleton {
+  pointer-events: none;
+}
+
+.user-detail__avatar-skeleton {
+  width: clamp(7rem, 14vw, 10rem);
+  height: clamp(7rem, 14vw, 10rem);
+  border-radius: 50%;
+  background: var(--c-uniandes-color-neutro-30);
+  position: relative;
+  overflow: hidden;
+}
+
+.user-detail__skeleton-lines {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.user-detail__skeleton-line {
+  height: 1rem;
+  border-radius: 0.25rem;
+  background: var(--c-uniandes-color-neutro-30);
+  position: relative;
+  overflow: hidden;
+}
+
+.user-detail__skeleton-line--lg {
+  width: 60%;
+  height: 2rem;
+}
+.user-detail__skeleton-line--md {
+  width: 30%;
+}
+.user-detail__skeleton-line--sm {
+  width: 45%;
+  height: 0.875rem;
+}
+
+.user-detail__avatar-skeleton::after,
+.user-detail__skeleton-line::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.6) 50%,
+    transparent 100%
+  );
+  transform: translateX(-100%);
+  animation: shimmer 1.4s infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .user-detail__avatar-skeleton::after,
+  .user-detail__skeleton-line::after {
+    animation: none;
+  }
+}
+
+/* ── Not found ───────────────────────────────────────────────────────── */
+.user-detail__not-found {
+  text-align: center;
+  padding: var(--space-8) var(--space-4);
+  background: var(--color-surface);
+  border: 1px dashed var(--color-border);
+  border-radius: 0.75rem;
+}
+
+.user-detail__not-found h1 {
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  margin: 0 0 var(--space-2);
+}
+
+.user-detail__not-found p {
+  margin: 0 0 var(--space-4);
+  color: var(--color-text-muted);
+}
+
+.user-detail__cta {
+  display: inline-block;
+  padding: 0.625rem 1.25rem;
+  font-weight: 500;
+  font-size: 0.9375rem;
+  color: var(--c-content-primary-default-lightbg);
+  background: var(--c-background-primary-default-lightbg);
+  border-radius: 0.5rem;
+  text-decoration: none;
+  transition:
+    background-color 160ms ease,
+    color 160ms ease,
+    transform 160ms ease;
+}
+
+.user-detail__cta:hover {
+  background: var(--c-uniandes-color-secondary-01-lightbg);
+  color: var(--c-uniandes-color-primarytext-lightbg);
+  transform: translateY(-1px);
+}
+
+.user-detail__cta:focus-visible {
+  outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
+  outline-offset: 2px;
+}

--- a/src/app/features/users/user-detail-page.html
+++ b/src/app/features/users/user-detail-page.html
@@ -1,0 +1,224 @@
+<section class="user-detail" aria-busy="false">
+  <a routerLink="/usuarios" class="user-detail__back">
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        d="M15 18l-6-6 6-6"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+    Volver a usuarios
+  </a>
+
+  @if (isLoading()) {
+    <div class="user-detail__hero user-detail__hero--skeleton" aria-hidden="true">
+      <div class="user-detail__avatar-skeleton"></div>
+      <div class="user-detail__skeleton-lines">
+        <div class="user-detail__skeleton-line user-detail__skeleton-line--lg"></div>
+        <div class="user-detail__skeleton-line user-detail__skeleton-line--md"></div>
+        <div class="user-detail__skeleton-line user-detail__skeleton-line--sm"></div>
+      </div>
+    </div>
+  } @else if (notFound()) {
+    <div class="user-detail__not-found">
+      <h1>Usuario no encontrado</h1>
+      <p>El usuario solicitado no existe o ha sido eliminado.</p>
+      <a routerLink="/usuarios" class="user-detail__cta">Ver todos los usuarios</a>
+    </div>
+  } @else if (user(); as u) {
+    <header class="user-detail__hero">
+      <div
+        class="user-detail__avatar-stage"
+        (mousemove)="onAvatarMove($event)"
+        (mouseleave)="onAvatarLeave()"
+      >
+        @if (avatarFailed()) {
+          <div
+            class="user-detail__avatar user-detail__avatar--initials"
+            [style.transform]="
+              'rotateX(' +
+              tilt().x +
+              'deg) rotateY(' +
+              tilt().y +
+              'deg) scale(' +
+              tilt().scale +
+              ')'
+            "
+            aria-hidden="true"
+          >
+            {{ initials() }}
+          </div>
+        } @else {
+          <img
+            class="user-detail__avatar"
+            [src]="u.avatarUrl"
+            [alt]="'Avatar de ' + u.name"
+            [style.transform]="
+              'rotateX(' +
+              tilt().x +
+              'deg) rotateY(' +
+              tilt().y +
+              'deg) scale(' +
+              tilt().scale +
+              ')'
+            "
+            width="160"
+            height="160"
+            decoding="async"
+            (error)="onAvatarError()"
+          />
+        }
+      </div>
+
+      <div class="user-detail__identity">
+        <p class="user-detail__eyebrow">
+          <span
+            class="user-detail__role user-detail__role--{{ u.role }}"
+            [attr.aria-label]="'Rol: ' + roleLabel()"
+          >
+            {{ roleLabel() }}
+          </span>
+        </p>
+        <h1 class="user-detail__name">{{ u.name }}</h1>
+        <p class="user-detail__username">&#64;{{ u.username }}</p>
+
+        <ul class="user-detail__meta">
+          <li class="user-detail__meta-item">
+            <a
+              [href]="mapsUrl()"
+              target="_blank"
+              rel="noopener noreferrer"
+              [attr.aria-label]="'Ver ' + u.location + ' en Google Maps (nueva pestaña)'"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path
+                  d="M12 2a7 7 0 0 0-7 7c0 5.25 7 13 7 13s7-7.75 7-13a7 7 0 0 0-7-7zm0 9.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5z"
+                  fill="currentColor"
+                />
+              </svg>
+              <span>{{ u.location }}</span>
+            </a>
+          </li>
+          <li class="user-detail__meta-item">
+            <a [href]="'mailto:' + u.email" [title]="u.email">
+              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path
+                  d="M4 4h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2zm0 4.4V18h16V8.4l-8 5-8-5z"
+                  fill="currentColor"
+                />
+              </svg>
+              <span>{{ u.email }}</span>
+            </a>
+          </li>
+          <li class="user-detail__meta-item user-detail__meta-item--static">
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path
+                d="M7 3a2 2 0 0 0-2 2v15a1 1 0 0 0 1.5.87L12 17.6l5.5 3.27A1 1 0 0 0 19 20V5a2 2 0 0 0-2-2H7zm0 2h10v13.27l-4.5-2.68a1 1 0 0 0-1 0L7 18.27V5z"
+                fill="currentColor"
+              />
+            </svg>
+            <span>{{ reposLabel() }}</span>
+          </li>
+        </ul>
+      </div>
+    </header>
+
+    <section class="user-detail__section" aria-labelledby="user-detail-repos-title">
+      <h2 id="user-detail-repos-title" class="user-detail__section-title">
+        Repositorios mantenidos
+      </h2>
+      @if (userRepos().length === 0) {
+        <p class="user-detail__empty">
+          {{ u.name }} todavía no tiene repositorios públicos en GhQuerry.
+        </p>
+      } @else {
+        <ul class="user-detail__repos-grid">
+          @for (repo of userRepos(); track repo.id) {
+            <li class="user-detail__repos-item">
+              <app-repository-card [repository]="repo" [owner]="u" />
+            </li>
+          }
+        </ul>
+      }
+    </section>
+
+    @if (otherUsers().length > 0) {
+      <section class="user-detail__section" aria-labelledby="user-detail-others-title">
+        <h2 id="user-detail-others-title" class="user-detail__section-title">
+          Otros developers de la comunidad
+        </h2>
+        <div class="user-detail__rail-wrapper">
+          <button
+            type="button"
+            class="user-detail__rail-arrow user-detail__rail-arrow--prev"
+            (click)="scrollRailPrev()"
+            [disabled]="!canScrollPrev()"
+            aria-label="Ver developers anteriores"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path
+                d="M15 18l-6-6 6-6"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2.25"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
+          <ul
+            #railEl
+            class="user-detail__rail"
+            aria-label="Otros developers"
+            (scroll)="onRailScroll()"
+          >
+            @for (other of otherUsers(); track other.id) {
+              <li class="user-detail__rail-item">
+                <a
+                  [routerLink]="['/usuarios', other.id]"
+                  class="other-user"
+                  [attr.aria-label]="'Ver detalle de ' + other.name"
+                >
+                  <img
+                    class="other-user__avatar"
+                    [src]="other.avatarUrl"
+                    [alt]=""
+                    width="56"
+                    height="56"
+                    loading="lazy"
+                    decoding="async"
+                  />
+                  <span class="other-user__name">{{ other.name }}</span>
+                  <span class="other-user__role other-user__role--{{ other.role }}">
+                    {{ roleOf(other) }}
+                  </span>
+                </a>
+              </li>
+            }
+          </ul>
+          <button
+            type="button"
+            class="user-detail__rail-arrow user-detail__rail-arrow--next"
+            (click)="scrollRailNext()"
+            [disabled]="!canScrollNext()"
+            aria-label="Ver más developers"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path
+                d="M9 6l6 6-6 6"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2.25"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
+        </div>
+      </section>
+    }
+  }
+</section>

--- a/src/app/features/users/user-detail-page.ts
+++ b/src/app/features/users/user-detail-page.ts
@@ -1,0 +1,185 @@
+import {
+  afterNextRender,
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  type ElementRef,
+  inject,
+  input,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { RouterLink } from '@angular/router';
+
+import { RepositoryCard } from '@shared/ui/repository-card/repository-card';
+import { Repositories } from '@features/repositories/repositories';
+import { Users } from './users';
+import type { Role, User } from './user';
+
+const ROLE_LABEL: Readonly<Record<Role, string>> = {
+  admin: 'Admin',
+  developer: 'Developer',
+  designer: 'Designer',
+};
+
+interface AvatarTilt {
+  readonly x: number;
+  readonly y: number;
+  readonly scale: number;
+}
+
+const AVATAR_REST: AvatarTilt = { x: 0, y: 0, scale: 1 };
+const AVATAR_MAX_TILT_DEG = 14;
+const AVATAR_MAX_SCALE = 1.18;
+const AVATAR_MIN_SCALE = 1.06;
+
+@Component({
+  selector: 'app-user-detail-page',
+  imports: [RouterLink, RepositoryCard],
+  templateUrl: './user-detail-page.html',
+  styleUrl: './user-detail-page.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class UserDetailPage {
+  /** Bound from the route param `:id` thanks to `withComponentInputBinding()`. */
+  readonly id = input.required<string>();
+
+  private readonly usersService = inject(Users);
+  private readonly reposService = inject(Repositories);
+
+  protected readonly avatarFailed = signal(false);
+  protected readonly tilt = signal<AvatarTilt>(AVATAR_REST);
+
+  /* ── Rail "Otros developers": control programático con flechas ─────── */
+  private readonly railEl = viewChild<ElementRef<HTMLElement>>('railEl');
+  protected readonly canScrollPrev = signal(false);
+  protected readonly canScrollNext = signal(false);
+
+  constructor() {
+    /* Inicializa el estado de las flechas tras el primer render del rail. */
+    afterNextRender(() => {
+      this.recomputeRailState();
+    });
+  }
+
+  protected onRailScroll(): void {
+    this.recomputeRailState();
+  }
+
+  protected scrollRailPrev(): void {
+    this.scrollRail(-1);
+  }
+
+  protected scrollRailNext(): void {
+    this.scrollRail(1);
+  }
+
+  private scrollRail(direction: -1 | 1): void {
+    const el = this.railEl()?.nativeElement;
+    if (!el) return;
+    /* Avanzamos ~80% del viewport del rail para mostrar contenido nuevo
+       conservando una card de contexto en el borde. */
+    const delta = el.clientWidth * 0.8 * direction;
+    el.scrollBy({ left: delta, behavior: 'smooth' });
+  }
+
+  private recomputeRailState(): void {
+    const el = this.railEl()?.nativeElement;
+    if (!el) return;
+    const max = el.scrollWidth - el.clientWidth;
+    this.canScrollPrev.set(el.scrollLeft > 0);
+    /* `-1` para tolerar redondeo subpixel. */
+    this.canScrollNext.set(max > 0 && el.scrollLeft < max - 1);
+  }
+
+  private readonly allUsers = toSignal(this.usersService.list(), { initialValue: undefined });
+  private readonly allRepos = toSignal(this.reposService.list(), { initialValue: undefined });
+
+  protected readonly isLoading = computed(
+    () => this.allUsers() === undefined || this.allRepos() === undefined,
+  );
+
+  protected readonly user = computed<User | undefined>(() => {
+    const list = this.allUsers();
+    if (!list) return undefined;
+    const numeric = Number(this.id());
+    return list.find((u) => u.id === numeric);
+  });
+
+  protected readonly notFound = computed(
+    () => this.allUsers() !== undefined && this.user() === undefined,
+  );
+
+  protected readonly userRepos = computed(() => {
+    const list = this.allRepos();
+    const u = this.user();
+    if (!list || !u) return [];
+    return list.filter((r) => u.ownsRepo(r.id));
+  });
+
+  protected readonly otherUsers = computed<readonly User[]>(() => {
+    const list = this.allUsers();
+    const u = this.user();
+    if (!list || !u) return [];
+    return list.filter((other) => other.id !== u.id);
+  });
+
+  protected readonly mapsUrl = computed(() => {
+    const u = this.user();
+    if (!u) return '#';
+    const query = encodeURIComponent(`${u.location}, Colombia`);
+    return `https://www.google.com/maps/search/?api=1&query=${query}`;
+  });
+
+  protected readonly roleLabel = computed(() => {
+    const u = this.user();
+    return u ? ROLE_LABEL[u.role] : '';
+  });
+
+  protected readonly initials = computed(() => {
+    const u = this.user();
+    if (!u) return '?';
+    const parts = u.name.trim().split(/\s+/).filter(Boolean);
+    const first = parts[0]?.[0] ?? '';
+    const last = parts.length > 1 ? (parts[parts.length - 1]?.[0] ?? '') : '';
+    return (first + last).toUpperCase() || '?';
+  });
+
+  protected readonly reposLabel = computed(() => {
+    const u = this.user();
+    if (!u) return '';
+    const n = u.repoIds.length;
+    if (n === 0) return 'Sin repositorios';
+    if (n === 1) return '1 repositorio';
+    return `${String(n)} repositorios`;
+  });
+
+  protected roleOf(other: User): string {
+    return ROLE_LABEL[other.role];
+  }
+
+  protected onAvatarError(): void {
+    this.avatarFailed.set(true);
+  }
+
+  protected onAvatarMove(event: MouseEvent): void {
+    const stage = event.currentTarget as HTMLElement;
+    const rect = stage.getBoundingClientRect();
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
+    const nx = (event.clientX - cx) / (rect.width / 2);
+    const ny = (event.clientY - cy) / (rect.height / 2);
+    const dist = Math.min(1, Math.hypot(nx, ny));
+    const scale = AVATAR_MAX_SCALE - (AVATAR_MAX_SCALE - AVATAR_MIN_SCALE) * dist;
+    this.tilt.set({
+      x: -ny * AVATAR_MAX_TILT_DEG,
+      y: nx * AVATAR_MAX_TILT_DEG,
+      scale,
+    });
+  }
+
+  protected onAvatarLeave(): void {
+    this.tilt.set(AVATAR_REST);
+  }
+}

--- a/src/app/shared/ui/filter-toolbar/select-field.html
+++ b/src/app/shared/ui/filter-toolbar/select-field.html
@@ -1,13 +1,8 @@
 <div class="select-field__wrap">
-  <select
-    class="select-field__control"
-    [value]="value() ?? ''"
-    [attr.aria-label]="ariaLabel()"
-    (change)="onChange($event)"
-  >
-    <option value="">{{ placeholder() }}</option>
+  <select class="select-field__control" [attr.aria-label]="ariaLabel()" (change)="onChange($event)">
+    <option value="" [selected]="value() === null">{{ placeholder() }}</option>
     @for (opt of options(); track $index) {
-      <option [value]="opt.value">{{ opt.label }}</option>
+      <option [value]="opt.value" [selected]="opt.value === value()">{{ opt.label }}</option>
     }
   </select>
   <svg class="select-field__chevron" viewBox="0 0 24 24" aria-hidden="true" focusable="false">

--- a/src/app/shared/ui/repository-card/repository-card.css
+++ b/src/app/shared/ui/repository-card/repository-card.css
@@ -183,6 +183,37 @@
   text-overflow: ellipsis;
 }
 
+.repo-card__owner-link,
+.repo-card__owner-link:visited {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  /* Hereda el muted del meta-value para no competir con el lenguaje y las
+     estrellitas como elementos visuales primarios; el subrayado en hover
+     deja claro que es interactivo. */
+  color: inherit;
+  text-decoration: none;
+  border-radius: 0.25rem;
+  transition: color 160ms ease;
+}
+
+.repo-card__owner-link:hover,
+.repo-card__owner-link:focus-visible {
+  color: var(--color-text);
+}
+
+.repo-card__owner-link:hover .repo-card__owner-name {
+  text-decoration: underline;
+}
+
+.repo-card__owner-name {
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .repo-card__owner-avatar {
   width: 1.25rem;
   height: 1.25rem;

--- a/src/app/shared/ui/repository-card/repository-card.html
+++ b/src/app/shared/ui/repository-card/repository-card.html
@@ -42,26 +42,32 @@
       <dt class="repo-card__meta-label">Propietario</dt>
       <dd class="repo-card__meta-value">
         @if (owner(); as o) {
-          @if (avatarFailed()) {
-            <span
-              class="repo-card__owner-avatar repo-card__owner-avatar--initials"
-              aria-hidden="true"
-            >
-              {{ ownerInitials() }}
-            </span>
-          } @else {
-            <img
-              class="repo-card__owner-avatar"
-              [src]="o.avatarUrl"
-              [alt]="'Avatar de ' + o.name"
-              width="20"
-              height="20"
-              loading="lazy"
-              decoding="async"
-              (error)="onOwnerAvatarError()"
-            />
-          }
-          <span>{{ o.name }}</span>
+          <a
+            class="repo-card__owner-link"
+            [routerLink]="['/usuarios', o.id]"
+            [attr.aria-label]="'Ver perfil de ' + o.name"
+          >
+            @if (avatarFailed()) {
+              <span
+                class="repo-card__owner-avatar repo-card__owner-avatar--initials"
+                aria-hidden="true"
+              >
+                {{ ownerInitials() }}
+              </span>
+            } @else {
+              <img
+                class="repo-card__owner-avatar"
+                [src]="o.avatarUrl"
+                [alt]=""
+                width="20"
+                height="20"
+                loading="lazy"
+                decoding="async"
+                (error)="onOwnerAvatarError()"
+              />
+            }
+            <span class="repo-card__owner-name">{{ o.name }}</span>
+          </a>
         } @else {
           <span class="repo-card__owner-unknown">Propietario desconocido</span>
         }

--- a/src/app/shared/ui/repository-card/repository-card.ts
+++ b/src/app/shared/ui/repository-card/repository-card.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, computed, input, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
 import type { Repository } from '@features/repositories/repository';
 import type { User } from '@features/users/user';
 
@@ -45,6 +46,7 @@ const BADGE_MIN_SCALE = 1.104;
 
 @Component({
   selector: 'app-repository-card',
+  imports: [RouterLink],
   templateUrl: './repository-card.html',
   styleUrl: './repository-card.css',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/shared/ui/user-card/user-card.css
+++ b/src/app/shared/ui/user-card/user-card.css
@@ -4,6 +4,7 @@
 }
 
 .user-card {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
@@ -13,10 +14,48 @@
   border: 1px solid var(--color-border);
   border-radius: 0.75rem;
   box-shadow: 0 1px 2px rgba(25, 25, 22, 0.04);
+  /* La card entera es clickeable (overlay link) → cursor pointer global. */
+  cursor: pointer;
   transition:
     transform 220ms cubic-bezier(0.2, 0, 0, 1),
     box-shadow 220ms cubic-bezier(0.2, 0, 0, 1),
     border-color 220ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+/* Overlay link: cubre toda la card → click navega al detalle. Los demás
+   interactivos (avatar-stage, location, email) se elevan con z-index para
+   capturar sus propios clicks/hovers. */
+.user-card__link {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  border-radius: inherit;
+}
+
+.user-card__link:focus-visible {
+  outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
+  outline-offset: 2px;
+}
+
+/* Los wrappers no capturan clicks → pasan al overlay link (que cubre toda
+   la card y navega al detalle). Solo los hijos realmente interactivos
+   (avatar-stage para tilt, location → Maps, email → mailto) re-activan
+   `pointer-events: auto` para conservar su propia interacción. */
+.user-card__header,
+.user-card__meta,
+.user-card__footer {
+  position: relative;
+  z-index: 2;
+  pointer-events: none;
+}
+
+.user-card__location,
+.user-card__email,
+.user-card__avatar-stage,
+.user-card__repos {
+  position: relative;
+  z-index: 3;
+  pointer-events: auto;
 }
 
 .user-card:hover,
@@ -250,7 +289,8 @@
   border-top: 1px solid var(--color-border);
 }
 
-.user-card__repos {
+.user-card__repos,
+.user-card__repos:visited {
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);
@@ -260,12 +300,31 @@
   padding: 0.25rem 0.625rem;
   border-radius: 999px;
   background: var(--c-uniandes-color-neutro-30);
+  text-decoration: none;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease;
 }
 
-.user-card__repos--empty {
+.user-card__repos:hover,
+.user-card__repos:focus-visible {
+  background: var(--c-uniandes-color-secondary-02-lightbg);
+  color: var(--c-uniandes-color-primarytext-lightbg);
+}
+
+.user-card__repos--empty,
+.user-card__repos--empty:visited {
   color: var(--color-text-muted);
   background: transparent;
   border: 1px dashed var(--color-border);
+}
+
+.user-card__repos--empty:hover,
+.user-card__repos--empty:focus-visible {
+  background: var(--c-uniandes-color-neutro-30);
+  border-color: var(--c-uniandes-color-neutro-50);
+  color: var(--color-text);
 }
 
 /* Focus visibility for any interactive child */

--- a/src/app/shared/ui/user-card/user-card.html
+++ b/src/app/shared/ui/user-card/user-card.html
@@ -1,4 +1,9 @@
 <article class="user-card" [attr.aria-labelledby]="'user-' + user().id + '-name'">
+  <a
+    class="user-card__link"
+    [routerLink]="['/usuarios', user().id]"
+    [attr.aria-label]="'Ver detalle de ' + user().name"
+  ></a>
   <header class="user-card__header">
     <div
       class="user-card__avatar-stage"
@@ -81,7 +86,13 @@
   </dl>
 
   <footer class="user-card__footer">
-    <span class="user-card__repos" [class.user-card__repos--empty]="user().repoIds.length === 0">
+    <a
+      class="user-card__repos"
+      [class.user-card__repos--empty]="user().repoIds.length === 0"
+      routerLink="/repositorios"
+      [queryParams]="{ owner: user().id }"
+      [attr.aria-label]="'Ver ' + repoLabel() + ' de ' + user().name"
+    >
       <svg class="user-card__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
         <path
           d="M7 3a2 2 0 0 0-2 2v15a1 1 0 0 0 1.5.87L12 17.6l5.5 3.27A1 1 0 0 0 19 20V5a2 2 0 0 0-2-2H7zm0 2h10v13.27l-4.5-2.68a1 1 0 0 0-1 0L7 18.27V5z"
@@ -89,6 +100,6 @@
         />
       </svg>
       {{ repoLabel() }}
-    </span>
+    </a>
   </footer>
 </article>

--- a/src/app/shared/ui/user-card/user-card.ts
+++ b/src/app/shared/ui/user-card/user-card.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, computed, input, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
 import type { Role, User } from '@features/users/user';
 
 const ROLE_LABEL: Readonly<Record<Role, string>> = {
@@ -20,6 +21,7 @@ const AVATAR_MIN_SCALE = 1.104;
 
 @Component({
   selector: 'app-user-card',
+  imports: [RouterLink],
   templateUrl: './user-card.html',
   styleUrl: './user-card.css',
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
## Summary

Implementa la HU "Detalle de Usuario" y conecta el listado de usuarios y el de repositorios mediante deep links navegables.

### Página `/usuarios/:id`
- **Hero prominente**: avatar grande (clamp 7-10rem) con tilt 3D + escala dinámica (idéntico al `UserCard`), h1 con franja amarilla Uniandes permanente, role chip, meta inline con location → Google Maps (`_blank`), email → mailto y conteo de repositorios.
- **Sección "Repositorios mantenidos"**: grid responsive de `RepositoryCard`s del usuario actual (con el `owner` ya pre-inyectado).
- **Sección "Otros developers de la comunidad"**: rail horizontal con todos los demás 29 usuarios (incluyendo los que no mantienen repos). Scrollbar nativo oculto y reemplazado por **flechas prev/next** que avanzan ~80% del viewport del rail con `scrollBy({ behavior: 'smooth' })`. Las flechas se ocultan al alcanzar los extremos del scroll.
- **Back link** "← Volver a usuarios", **skeleton** del hero durante la carga, y **estado "Usuario no encontrado"** con CTA.

### Deep linking
- **`UserCard` → `/usuarios/:id`**: la card es navegable como conjunto vía overlay link (`<a class="user-card__link">` con `position: absolute; inset: 0`). Los interactivos internos (email → mailto, location → Maps, avatar tilt) re-activan `pointer-events: auto` con `z-index: 3` para conservar su propia interacción.
- **`UserCard` "X repositorios" → `/repositorios?owner=:id`**: el badge de repos pasa de `<span>` a `<a routerLink>` con queryParams. El `RepositoriesPage` lee el query param vía `ActivatedRoute.queryParamMap` envuelto con `toSignal`, y un `effect` pre-aplica el filtro a `ownerIdStr`.
- **`RepositoryCard` propietario → `/usuarios/:id`**: el avatar mini + nombre del owner se envuelven en `<a routerLink>` para navegar al perfil.

### Ajustes de soporte
- `RepositoriesPage.ownerOptions` ahora incluye **todos** los usuarios (no solo los que tienen repos) para que el SelectField muestre correctamente al owner cuando se llega con `?owner=:id` desde un usuario con 0 repos.
- `SelectField` ahora bindea `[selected]` por opción en lugar de `[value]` en el `<select>`, evitando un bug de timing cuando las opciones se cargan async (el placeholder permanecía visible aunque internamente había un valor seleccionado).
- `withComponentInputBinding()` habilitado en `provideRouter` (queda como base para futuras rutas que lo necesiten).

## Test plan
- [ ] `npm run typecheck`, `npm run lint`, `npm run format:check`, `npx ng test --watch=false`.
- [ ] `docker compose -f docker-compose.dev.yml up` → abrir `/usuarios`.
- [ ] Click en cualquier card → navega a `/usuarios/:id` con el hero, sus repos y el rail de otros developers.
- [ ] Click en el badge "X repositorios" de una card → `/repositorios?owner=:id`. Verificar que el SelectField del filtro de propietario muestra el nombre del usuario seleccionado y que solo se listan sus repos.
- [ ] Click en el badge "Sin repositorios" de un usuario sin repos (e.g., User Twenty Two) → repos vacío con CTA "Limpiar filtros" y SelectField mostrando ese usuario.
- [ ] En `/usuarios/:id`, click en el nombre del propietario de un `RepositoryCard` → navega a `/usuarios/:ownerId`.
- [ ] En `/usuarios/:id`, scroll del rail con flechas prev/next; al final / inicio las flechas correspondientes se ocultan; swipe táctil sigue funcionando.
- [ ] Hover sobre cualquier avatar → tilt 3D + escala según trayectoria del cursor.
- [ ] Click en "Volver a usuarios" → vuelve al listado.
- [ ] `prefers-reduced-motion: reduce` deshabilita tilt, scroll-behavior smooth y animaciones de entrada.

## Commits
- `cf61a7e` — `feat(users): user detail page + cross-feature deep linking`