### PR TITLE
feat(repositories): vista de detalle de repositorio + deep linking por rol y lenguaje

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -44,8 +44,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "8kB",
-                  "maximumError": "16kB"
+                  "maximumWarning": "14kB",
+                  "maximumError": "18kB"
                 }
               ],
               "outputHashing": "all"
@@ -67,8 +67,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "8kB",
-                  "maximumError": "16kB"
+                  "maximumWarning": "14kB",
+                  "maximumError": "18kB"
                 }
               ]
             }

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -8,6 +8,7 @@ import {
   provideRouter,
   TitleStrategy,
   withComponentInputBinding,
+  withInMemoryScrolling,
   withPreloading,
 } from '@angular/router';
 import { provideHttpClient, withFetch, withInterceptorsFromDi } from '@angular/common/http';
@@ -20,7 +21,15 @@ import { AppTitleStrategy } from './core/providers/app-title-strategy';
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
-    provideRouter(routes, withPreloading(PreloadAllModules), withComponentInputBinding()),
+    provideRouter(
+      routes,
+      withPreloading(PreloadAllModules),
+      withComponentInputBinding(),
+      /* `scrollPositionRestoration: 'enabled'` → al navegar a una nueva ruta
+         (e.g., card click → /usuarios/:id) hace scroll al top; al volver
+         atrás con el browser restaura la posición previa. */
+      withInMemoryScrolling({ scrollPositionRestoration: 'enabled' }),
+    ),
     provideHttpClient(withFetch(), withInterceptorsFromDi()),
     provideClientHydration(withEventReplay()),
     { provide: ErrorHandler, useClass: GlobalErrorHandler },

--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -28,6 +28,20 @@ export const serverRoutes: ServerRoute[] = [
     },
   },
   {
+    path: 'repositorios/:id',
+    renderMode: RenderMode.Prerender,
+    getPrerenderParams: async () => {
+      const response = await fetch(environment.apis.repositories);
+      if (!response.ok) {
+        throw new Error(
+          'Failed to fetch repositories for prerender: HTTP ' + String(response.status),
+        );
+      }
+      const repos = (await response.json()) as ReadonlyArray<{ id: number }>;
+      return repos.map((r) => ({ id: String(r.id) }));
+    },
+  },
+  {
     path: '**',
     renderMode: RenderMode.Prerender,
   },

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -45,6 +45,18 @@ export const routes: Routes = [
             'Repositorios destacados de la comunidad GhQuerry: lenguajes, popularidad y descripción de cada proyecto.',
         },
       },
+      {
+        path: 'repositorios/:id',
+        loadComponent: () =>
+          import('./features/repositories/repository-detail-page').then(
+            (m) => m.RepositoryDetailPage,
+          ),
+        title: 'Detalle de repositorio',
+        data: {
+          description:
+            'Perfil detallado de un repositorio GhQuerry: lenguaje, popularidad, propietario y proyectos relacionados de la comunidad.',
+        },
+      },
     ],
   },
 ];

--- a/src/app/features/repositories/repositories-page.ts
+++ b/src/app/features/repositories/repositories-page.ts
@@ -49,18 +49,14 @@ export class RepositoriesPage {
   protected readonly pageSize = 6;
 
   /**
-   * Query param `?owner=:id` leído reactivamente desde `ActivatedRoute`.
-   * Cuando se entra desde el badge de repositorios de un `UserCard`,
-   * pre-aplica el filtro de propietario.
+   * Query params leídos reactivamente desde `ActivatedRoute`. Pre-aplica
+   * los filtros internos cuando se entra con `?owner=:id` (desde el badge
+   * de repos de un `UserCard`) o `?language=:name` (desde el chip de
+   * lenguaje de un `RepositoryCard`).
    */
-  private readonly ownerFromUrl = toSignal(
-    this.route.queryParamMap
-      .pipe
-      // Map a string | null para comparar/asignar fácilmente.
-      // (queryParamMap.get devuelve null cuando no existe).
-      (),
-    { initialValue: this.route.snapshot.queryParamMap },
-  );
+  private readonly queryParams = toSignal(this.route.queryParamMap, {
+    initialValue: this.route.snapshot.queryParamMap,
+  });
 
   /* ── Estado de filtros ─────────────────────────────────────────────── */
   protected readonly query = signal('');
@@ -157,17 +153,23 @@ export class RepositoriesPage {
   protected readonly skeletonSlots = Array.from({ length: this.pageSize }, (_, i) => i);
 
   constructor() {
-    /* Cuando se entra desde un UserCard con `?owner=:id`, sincroniza el
-       query param al filtro interno. `untracked` para no crear un loop
-       cuando el efecto siguiente lee el filtro derivado. */
+    /* Cuando se entra desde otra página con `?owner=:id` (badge de repos
+       de un UserCard) o `?language=:name` (chip de lenguaje de un
+       RepositoryCard), sincroniza los query params a los filtros internos.
+       `untracked` evita un loop con el efecto siguiente que reacciona a
+       cambios en `filters()`. */
     effect(() => {
-      const fromUrl = this.ownerFromUrl().get('owner');
-      if (fromUrl !== null) {
-        const current = untracked(() => this.ownerIdStr());
-        if (current !== fromUrl) {
-          this.ownerIdStr.set(fromUrl);
+      const params = this.queryParams();
+      const ownerParam = params.get('owner');
+      const languageParam = params.get('language');
+      untracked(() => {
+        if (ownerParam !== null && this.ownerIdStr() !== ownerParam) {
+          this.ownerIdStr.set(ownerParam);
         }
-      }
+        if (languageParam !== null && this.language() !== languageParam) {
+          this.language.set(languageParam);
+        }
+      });
     });
 
     /* Cualquier cambio en filtros nos devuelve a la página 1. */

--- a/src/app/features/repositories/repository-detail-page.css
+++ b/src/app/features/repositories/repository-detail-page.css
@@ -14,14 +14,14 @@
   }
 }
 
-.user-detail {
+.repo-detail {
   display: flex;
   flex-direction: column;
   gap: var(--space-8);
 }
 
 /* ── Back link ───────────────────────────────────────────────────────── */
-.user-detail__back {
+.repo-detail__back {
   display: inline-flex;
   align-items: center;
   gap: 0.375rem;
@@ -41,34 +41,34 @@
     transform 160ms ease;
 }
 
-.user-detail__back:hover {
+.repo-detail__back:hover {
   color: var(--color-text);
   border-color: var(--c-uniandes-color-neutro-50);
   background: var(--color-surface);
   transform: translateX(-2px);
 }
 
-.user-detail__back:focus-visible {
+.repo-detail__back:focus-visible {
   outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
   outline-offset: 2px;
 }
 
-.user-detail__back svg {
+.repo-detail__back svg {
   width: 1rem;
   height: 1rem;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .user-detail__back {
+  .repo-detail__back {
     transition: none;
   }
-  .user-detail__back:hover {
+  .repo-detail__back:hover {
     transform: none;
   }
 }
 
 /* ── Hero ────────────────────────────────────────────────────────────── */
-.user-detail__hero {
+.repo-detail__hero {
   display: grid;
   grid-template-columns: auto 1fr;
   gap: clamp(1.5rem, 4vw, 2.5rem);
@@ -81,26 +81,27 @@
 }
 
 @media (max-width: 640px) {
-  .user-detail__hero {
+  .repo-detail__hero {
     grid-template-columns: 1fr;
     text-align: center;
     justify-items: center;
   }
 }
 
-.user-detail__avatar-stage {
+.repo-detail__badge-stage {
   width: clamp(7rem, 14vw, 10rem);
   height: clamp(7rem, 14vw, 10rem);
   flex-shrink: 0;
   perspective: 800px;
 }
 
-.user-detail__avatar {
+.repo-detail__badge {
+  display: grid;
+  place-items: center;
   width: 100%;
   height: 100%;
-  border-radius: 50%;
-  object-fit: cover;
-  background: var(--c-uniandes-color-neutro-30);
+  border-radius: clamp(1rem, 2vw, 1.5rem);
+  color: #fff;
   border: 4px solid var(--color-bg);
   box-shadow:
     0 0 0 1px var(--color-border),
@@ -110,45 +111,50 @@
   will-change: transform;
 }
 
-.user-detail__avatar--initials {
-  display: grid;
-  place-items: center;
-  font-size: clamp(2rem, 4.5vw, 3rem);
-  font-weight: 700;
-  color: var(--c-uniandes-color-primarytext-lightbg);
-  background: var(--c-uniandes-color-secondary-02-lightbg);
+.repo-detail__badge svg {
+  width: 50%;
+  height: 50%;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .user-detail__avatar {
+  .repo-detail__badge {
     transition: none;
     transform: none !important;
   }
 }
 
-.user-detail__identity {
+.repo-detail__identity {
   min-width: 0;
 }
 
-.user-detail__eyebrow {
+.repo-detail__eyebrow {
   margin: 0;
 }
 
-.user-detail__role,
-.user-detail__role:visited {
+.repo-detail__lang,
+.repo-detail__lang:visited {
   display: inline-flex;
   align-items: center;
-  gap: 0.4375rem;
+  gap: 0.5rem;
   font-size: 0.75rem;
   font-weight: 700;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  padding: 0.375rem 0.75rem 0.375rem 0.625rem;
+  padding: 0.375rem 0.875rem 0.375rem 0.75rem;
   border-radius: 999px;
-  border: 1px solid transparent;
+  /* Gradiente teñido por el lenguaje (`--lang-tint` lo setea el componente
+     vía `[style.--lang-tint]="languageColor()"`). 12/24% sobre `transparent`
+     mantiene legibilidad del texto en el surface del hero. */
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--lang-tint, var(--c-uniandes-color-neutro-50)) 12%, transparent) 0%,
+    color-mix(in srgb, var(--lang-tint, var(--c-uniandes-color-neutro-50)) 24%, transparent) 100%
+  );
+  color: var(--color-text);
+  border: 1px solid color-mix(in srgb, var(--lang-tint, var(--color-border)) 40%, transparent);
   white-space: nowrap;
   text-decoration: none;
-  /* Anillo arranca en 0 y se anima a un halo color del rol en hover. */
+  /* Anillo arranca en 0 y aparece con overshoot ligero en hover. */
   box-shadow: 0 0 0 0 transparent;
   transition:
     box-shadow 280ms cubic-bezier(0.34, 1.4, 0.64, 1),
@@ -157,83 +163,43 @@
     filter 200ms ease;
 }
 
-.user-detail__role::before {
-  content: '';
-  width: 0.5rem;
-  height: 0.5rem;
-  border-radius: 50%;
-  background: currentColor;
-  opacity: 0.65;
-  flex-shrink: 0;
-  transition: opacity 200ms ease;
-}
-
-.user-detail__role:hover,
-.user-detail__role:focus-visible {
-  box-shadow: 0 0 0 5px var(--user-detail-role-ring, transparent);
+.repo-detail__lang:hover,
+.repo-detail__lang:focus-visible {
+  /* Halo en el color del lenguaje. */
+  box-shadow: 0 0 0 5px color-mix(in srgb, var(--lang-tint, var(--color-border)) 35%, transparent);
   transform: translateY(-1px);
   filter: brightness(0.97);
 }
 
-.user-detail__role:hover::before,
-.user-detail__role:focus-visible::before {
-  opacity: 1;
-}
-
 @media (prefers-reduced-motion: reduce) {
-  .user-detail__role,
-  .user-detail__role::before {
+  .repo-detail__lang {
     transition: none;
   }
-  .user-detail__role:hover,
-  .user-detail__role:focus-visible {
+  .repo-detail__lang:hover,
+  .repo-detail__lang:focus-visible {
     transform: none;
     filter: none;
   }
 }
 
-.user-detail__role--admin,
-.user-detail__role--admin:visited {
-  background: linear-gradient(
-    135deg,
-    var(--c-uniandes-color-secondary-02-lightbg) 0%,
-    #ffd840 100%
-  );
-  color: var(--c-uniandes-color-primarytext-lightbg);
-  border-color: var(--c-uniandes-color-secondary-01-lightbg);
-  --user-detail-role-ring: rgba(255, 228, 30, 0.45);
+.repo-detail__lang-dot {
+  width: 0.625rem;
+  height: 0.625rem;
+  border-radius: 50%;
+  display: inline-block;
+  /* El dot a opacidad completa contrasta con el bg tintado al 12–24%. */
+  background: var(--lang-tint, currentColor);
+  flex-shrink: 0;
 }
 
-.user-detail__role--developer,
-.user-detail__role--developer:visited {
-  background: linear-gradient(
-    135deg,
-    var(--c-uniandes-color-neutro-30) 0%,
-    var(--c-uniandes-color-neutro-40) 100%
-  );
-  color: var(--c-uniandes-color-primarytext-lightbg);
-  border-color: var(--c-uniandes-color-neutro-50);
-  --user-detail-role-ring: rgba(138, 137, 132, 0.35);
-}
-
-.user-detail__role--designer,
-.user-detail__role--designer:visited {
-  background: linear-gradient(135deg, rgba(36, 66, 178, 0.08) 0%, rgba(36, 66, 178, 0.18) 100%);
-  color: var(--color-accent);
-  border-color: rgba(36, 66, 178, 0.35);
-  --user-detail-role-ring: rgba(36, 66, 178, 0.3);
-}
-
-.user-detail__name {
+.repo-detail__name {
   font-size: clamp(2rem, 5vw, 3rem);
   font-weight: 700;
   letter-spacing: -0.01em;
   line-height: 1.1;
-  margin: 0.5rem 0 0.25rem;
+  margin: 0.5rem 0 0.75rem;
   color: var(--color-text);
-  /* Franja amarilla Uniandes bajo el nombre — destaca como título focal
-     de la página de detalle. `width: fit-content` ajusta la franja al
-     ancho del texto en lugar de extenderla a todo el contenedor. */
+  /* Franja amarilla Uniandes destacando el nombre como título focal. */
   width: fit-content;
   max-width: 100%;
   background-image: linear-gradient(
@@ -246,20 +212,27 @@
 }
 
 @media (max-width: 640px) {
-  .user-detail__name {
+  .repo-detail__name {
     margin-inline: auto;
   }
 }
 
-.user-detail__username {
+.repo-detail__description {
   margin: 0;
   font-size: clamp(0.9375rem, 1.5vw, 1.0625rem);
+  line-height: 1.55;
   color: var(--color-text-muted);
-  font-feature-settings: 'tnum' 1;
+  max-width: 60ch;
+}
+
+@media (max-width: 640px) {
+  .repo-detail__description {
+    margin-inline: auto;
+  }
 }
 
 /* ── Meta inline ─────────────────────────────────────────────────────── */
-.user-detail__meta {
+.repo-detail__meta {
   list-style: none;
   padding: 0;
   margin: var(--space-4) 0 0;
@@ -268,118 +241,143 @@
   gap: var(--space-2) var(--space-4);
   font-size: 0.9375rem;
   color: var(--color-text-muted);
+  align-items: center;
 }
 
-.user-detail__meta-item {
+.repo-detail__meta-item {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: 0.5rem;
   min-width: 0;
 }
 
-.user-detail__meta-item svg {
+.repo-detail__meta-item svg {
   width: 1rem;
   height: 1rem;
   color: var(--c-uniandes-color-neutro-70);
   flex-shrink: 0;
 }
 
-.user-detail__meta-item a {
+.repo-detail__meta-item--static {
+  color: var(--color-text-muted);
+}
+
+.repo-detail__owner-link,
+.repo-detail__owner-link:visited {
   display: inline-flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: 0.5rem;
   color: inherit;
   text-decoration: none;
   border-radius: 0.25rem;
   transition: color 160ms ease;
 }
 
-.user-detail__meta-item a:hover {
+.repo-detail__owner-link:hover,
+.repo-detail__owner-link:focus-visible {
   color: var(--color-text);
 }
 
-.user-detail__meta-item a:hover span {
+.repo-detail__owner-link:hover .repo-detail__owner-name {
   text-decoration: underline;
 }
 
-.user-detail__meta-item a:focus-visible {
+.repo-detail__owner-link:focus-visible {
   outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
   outline-offset: 2px;
 }
 
-.user-detail__meta-item--static {
-  color: var(--color-text-muted);
+.repo-detail__owner-avatar {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+  background: var(--c-uniandes-color-neutro-30);
+  border: 2px solid var(--color-bg);
+  box-shadow: 0 0 0 1px var(--color-border);
+}
+
+.repo-detail__owner-avatar--initials {
+  display: grid;
+  place-items: center;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: var(--color-text);
+  background: var(--c-uniandes-color-secondary-02-lightbg);
+}
+
+.repo-detail__owner-name {
+  font-weight: 500;
+}
+
+.repo-detail__owner-unknown {
+  font-style: italic;
+  color: var(--color-text-disabled);
 }
 
 @media (max-width: 640px) {
-  .user-detail__meta {
+  .repo-detail__meta {
     justify-content: center;
   }
 }
 
-/* ── Section blocks (repos + others) ─────────────────────────────────── */
-.user-detail__section {
+/* ── Stars badge (igual que RepositoryCard, con 4 tiers) ─────────────── */
+.repo-detail__stars {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  padding: 0.3125rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+}
+
+.repo-detail__stars--low {
+  background: var(--c-uniandes-color-neutro-30);
+  color: var(--color-text);
+  border-color: var(--color-border);
+}
+.repo-detail__stars--mid {
+  background: rgba(36, 66, 178, 0.08);
+  color: var(--color-accent);
+  border-color: rgba(36, 66, 178, 0.25);
+}
+.repo-detail__stars--high {
+  background: rgba(11, 115, 16, 0.1);
+  color: var(--c-uniandes-color-success-lightbg);
+  border-color: rgba(11, 115, 16, 0.3);
+}
+.repo-detail__stars--top {
+  background: var(--c-uniandes-color-secondary-02-lightbg);
+  color: var(--c-uniandes-color-primarytext-lightbg);
+  border-color: var(--c-uniandes-color-secondary-01-lightbg);
+}
+.repo-detail__stars--top svg {
+  color: var(--c-uniandes-color-alert-lightbg);
+}
+
+/* ── Section blocks (otros repos del owner / similares) ──────────────── */
+.repo-detail__section {
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
 }
 
-.user-detail__section-title {
+.repo-detail__section-title {
   font-size: clamp(1.25rem, 2vw, 1.5rem);
   font-weight: 600;
   margin: 0;
   color: var(--color-text);
 }
 
-.user-detail__empty {
-  margin: 0;
-  padding: var(--space-6);
-  border: 1px dashed var(--color-border);
-  border-radius: 0.5rem;
-  background: var(--color-surface);
-  color: var(--color-text-muted);
-  text-align: center;
-  font-size: 0.9375rem;
-}
-
-/* ── Repos grid (mismo CSS Grid uniforme que las otras páginas) ──────── */
-.user-detail__repos-grid {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(min(18rem, 100%), 1fr));
-  gap: var(--space-6);
-}
-
-.user-detail__repos-item {
-  min-width: 0;
-  opacity: 0;
-  transform: translateY(8px);
-  animation: fadeUp 420ms cubic-bezier(0.2, 0, 0, 1) forwards;
-}
-
-.user-detail__repos-item:nth-child(1) {
-  animation-delay: 60ms;
-}
-.user-detail__repos-item:nth-child(2) {
-  animation-delay: 120ms;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .user-detail__repos-item {
-    animation: none;
-    opacity: 1;
-    transform: none;
-  }
-}
-
-/* ── Rail horizontal de "otros usuarios" ─────────────────────────────── */
-.user-detail__rail-wrapper {
+/* ── Rail horizontal ─────────────────────────────────────────────────── */
+.repo-detail__rail-wrapper {
   position: relative;
 }
 
-.user-detail__rail {
+.repo-detail__rail {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -388,18 +386,37 @@
   overflow-x: auto;
   scroll-behavior: smooth;
   scroll-snap-type: x proximity;
-  /* Scrollbar nativa oculta — la navegación del rail se hace con las
-     flechas. Mantenemos overflow auto para conservar swipe táctil y
-     scroll-wheel horizontal. */
   scrollbar-width: none;
 }
 
-.user-detail__rail::-webkit-scrollbar {
+.repo-detail__rail::-webkit-scrollbar {
   display: none;
 }
 
-/* ── Flechas de control ──────────────────────────────────────────────── */
-.user-detail__rail-arrow {
+@media (prefers-reduced-motion: reduce) {
+  .repo-detail__rail {
+    scroll-behavior: auto;
+  }
+}
+
+.repo-detail__rail-item {
+  scroll-snap-align: start;
+  flex-shrink: 0;
+}
+
+/* En viewports estrechos, una mini-card aislada llena el ancho del rail
+   en lugar de quedarse a 14rem con espacio vacío a la derecha. Si hay
+   varias mini-cards, mantienen su ancho fijo para preservar el patrón
+   de carrusel deslizable. */
+@media (max-width: 640px) {
+  .repo-detail__rail-item:only-child,
+  .repo-detail__rail-item:only-child .other-repo {
+    width: 100%;
+  }
+}
+
+/* ── Flechas de control del rail ─────────────────────────────────────── */
+.repo-detail__rail-arrow {
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
@@ -423,103 +440,99 @@
     transform 160ms ease;
 }
 
-.user-detail__rail-arrow:hover:not(:disabled) {
+.repo-detail__rail-arrow:hover:not(:disabled) {
   background: var(--c-uniandes-color-secondary-01-lightbg);
   border-color: var(--c-uniandes-color-secondary-01-lightbg);
   color: var(--c-uniandes-color-primarytext-lightbg);
   transform: translateY(-50%) scale(1.06);
 }
 
-.user-detail__rail-arrow:focus-visible {
+.repo-detail__rail-arrow:focus-visible {
   outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
   outline-offset: 2px;
 }
 
-.user-detail__rail-arrow:disabled {
+.repo-detail__rail-arrow:disabled {
   opacity: 0;
   pointer-events: none;
 }
 
-.user-detail__rail-arrow svg {
+.repo-detail__rail-arrow svg {
   width: 1.125rem;
   height: 1.125rem;
 }
 
-.user-detail__rail-arrow--prev {
+.repo-detail__rail-arrow--prev {
   left: -0.5rem;
 }
 
-.user-detail__rail-arrow--next {
+.repo-detail__rail-arrow--next {
   right: -0.5rem;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .user-detail__rail {
-    scroll-behavior: auto;
-  }
-  .user-detail__rail-arrow {
+  .repo-detail__rail-arrow {
     transition: none;
   }
-  .user-detail__rail-arrow:hover:not(:disabled) {
+  .repo-detail__rail-arrow:hover:not(:disabled) {
     transform: translateY(-50%);
   }
 }
 
-.user-detail__rail-item {
-  scroll-snap-align: start;
-  flex-shrink: 0;
-}
-
-.other-user {
+/* ── Mini repo card del rail ─────────────────────────────────────────── */
+.other-repo {
   display: grid;
-  grid-template-rows: auto auto auto;
-  gap: 0.375rem;
-  width: 11rem;
+  grid-template-rows: auto auto auto auto;
+  gap: var(--space-2);
+  width: 14rem;
   padding: var(--space-4);
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: 0.75rem;
   text-decoration: none;
   color: inherit;
-  text-align: center;
-  justify-items: center;
+  justify-items: start;
   transition:
     transform 220ms cubic-bezier(0.2, 0, 0, 1),
     border-color 220ms cubic-bezier(0.2, 0, 0, 1),
     box-shadow 220ms cubic-bezier(0.2, 0, 0, 1);
 }
 
-.other-user:hover {
+.other-repo:hover {
   transform: translateY(-2px);
   border-color: var(--c-uniandes-color-neutro-50);
   box-shadow: 0 6px 18px rgba(25, 25, 22, 0.08);
 }
 
-.other-user:focus-visible {
+.other-repo:focus-visible {
   outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
   outline-offset: 2px;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .other-user {
+  .other-repo {
     transition: none;
   }
-  .other-user:hover {
+  .other-repo:hover {
     transform: none;
   }
 }
 
-.other-user__avatar {
-  width: 3.5rem;
-  height: 3.5rem;
-  border-radius: 50%;
-  object-fit: cover;
-  background: var(--c-uniandes-color-neutro-30);
-  border: 2px solid var(--color-bg);
-  box-shadow: 0 0 0 1px var(--color-border);
+.other-repo__badge {
+  display: grid;
+  place-items: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 0.5rem;
+  color: #fff;
 }
 
-.other-user__name {
+.other-repo__badge svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.other-repo__name {
   font-size: 0.9375rem;
   font-weight: 600;
   color: var(--color-text);
@@ -529,56 +542,108 @@
   max-width: 100%;
 }
 
-.other-user__role {
-  font-size: 0.6875rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  padding: 0.125rem 0.5rem;
+.other-repo__description {
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+  /* 2 líneas como máximo */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  overflow: hidden;
+  max-width: 100%;
+}
+
+/* Owner del rail "Repositorios similares en {language}" — avatar mini +
+   nombre, alineado a la izquierda y truncado si es largo. */
+.other-repo__owner {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  min-width: 0;
+  max-width: 100%;
+}
+
+.other-repo__owner-avatar {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+  background: var(--c-uniandes-color-neutro-30);
+  border: 1px solid var(--color-border);
+}
+
+.other-repo__owner-name {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.other-repo__stars {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 0.1875rem 0.5rem;
   border-radius: 999px;
   border: 1px solid transparent;
-  white-space: nowrap;
 }
 
-.other-user__role--admin {
-  background: var(--c-uniandes-color-secondary-02-lightbg);
-  color: var(--c-uniandes-color-primarytext-lightbg);
-  border-color: var(--c-uniandes-color-secondary-01-lightbg);
+.other-repo__stars svg {
+  width: 0.75rem;
+  height: 0.75rem;
 }
 
-.other-user__role--developer {
+.other-repo__stars--low {
   background: var(--c-uniandes-color-neutro-30);
-  color: var(--c-uniandes-color-primarytext-lightbg);
+  color: var(--color-text);
   border-color: var(--color-border);
 }
-
-.other-user__role--designer {
+.other-repo__stars--mid {
   background: rgba(36, 66, 178, 0.08);
   color: var(--color-accent);
   border-color: rgba(36, 66, 178, 0.25);
 }
+.other-repo__stars--high {
+  background: rgba(11, 115, 16, 0.1);
+  color: var(--c-uniandes-color-success-lightbg);
+  border-color: rgba(11, 115, 16, 0.3);
+}
+.other-repo__stars--top {
+  background: var(--c-uniandes-color-secondary-02-lightbg);
+  color: var(--c-uniandes-color-primarytext-lightbg);
+  border-color: var(--c-uniandes-color-secondary-01-lightbg);
+}
+.other-repo__stars--top svg {
+  color: var(--c-uniandes-color-alert-lightbg);
+}
 
 /* ── Skeleton del hero ───────────────────────────────────────────────── */
-.user-detail__hero--skeleton {
+.repo-detail__hero--skeleton {
   pointer-events: none;
 }
 
-.user-detail__avatar-skeleton {
+.repo-detail__badge-skeleton {
   width: clamp(7rem, 14vw, 10rem);
   height: clamp(7rem, 14vw, 10rem);
-  border-radius: 50%;
+  border-radius: clamp(1rem, 2vw, 1.5rem);
   background: var(--c-uniandes-color-neutro-30);
   position: relative;
   overflow: hidden;
 }
 
-.user-detail__skeleton-lines {
+.repo-detail__skeleton-lines {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
 }
 
-.user-detail__skeleton-line {
+.repo-detail__skeleton-line {
   height: 1rem;
   border-radius: 0.25rem;
   background: var(--c-uniandes-color-neutro-30);
@@ -586,20 +651,20 @@
   overflow: hidden;
 }
 
-.user-detail__skeleton-line--lg {
+.repo-detail__skeleton-line--lg {
   width: 60%;
   height: 2rem;
 }
-.user-detail__skeleton-line--md {
-  width: 30%;
+.repo-detail__skeleton-line--md {
+  width: 80%;
 }
-.user-detail__skeleton-line--sm {
+.repo-detail__skeleton-line--sm {
   width: 45%;
   height: 0.875rem;
 }
 
-.user-detail__avatar-skeleton::after,
-.user-detail__skeleton-line::after {
+.repo-detail__badge-skeleton::after,
+.repo-detail__skeleton-line::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -614,14 +679,14 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .user-detail__avatar-skeleton::after,
-  .user-detail__skeleton-line::after {
+  .repo-detail__badge-skeleton::after,
+  .repo-detail__skeleton-line::after {
     animation: none;
   }
 }
 
 /* ── Not found ───────────────────────────────────────────────────────── */
-.user-detail__not-found {
+.repo-detail__not-found {
   text-align: center;
   padding: var(--space-8) var(--space-4);
   background: var(--color-surface);
@@ -629,17 +694,17 @@
   border-radius: 0.75rem;
 }
 
-.user-detail__not-found h1 {
+.repo-detail__not-found h1 {
   font-size: clamp(1.5rem, 3vw, 2rem);
   margin: 0 0 var(--space-2);
 }
 
-.user-detail__not-found p {
+.repo-detail__not-found p {
   margin: 0 0 var(--space-4);
   color: var(--color-text-muted);
 }
 
-.user-detail__cta {
+.repo-detail__cta {
   display: inline-block;
   padding: 0.625rem 1.25rem;
   font-weight: 500;
@@ -654,13 +719,13 @@
     transform 160ms ease;
 }
 
-.user-detail__cta:hover {
+.repo-detail__cta:hover {
   background: var(--c-uniandes-color-secondary-01-lightbg);
   color: var(--c-uniandes-color-primarytext-lightbg);
   transform: translateY(-1px);
 }
 
-.user-detail__cta:focus-visible {
+.repo-detail__cta:focus-visible {
   outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
   outline-offset: 2px;
 }

--- a/src/app/features/repositories/repository-detail-page.html
+++ b/src/app/features/repositories/repository-detail-page.html
@@ -1,0 +1,313 @@
+<section class="repo-detail">
+  <a routerLink="/repositorios" class="repo-detail__back">
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        d="M15 18l-6-6 6-6"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+    Volver a repositorios
+  </a>
+
+  @if (isLoading()) {
+    <div class="repo-detail__hero repo-detail__hero--skeleton" aria-hidden="true">
+      <div class="repo-detail__badge-skeleton"></div>
+      <div class="repo-detail__skeleton-lines">
+        <div class="repo-detail__skeleton-line repo-detail__skeleton-line--lg"></div>
+        <div class="repo-detail__skeleton-line repo-detail__skeleton-line--md"></div>
+        <div class="repo-detail__skeleton-line repo-detail__skeleton-line--sm"></div>
+      </div>
+    </div>
+  } @else if (notFound()) {
+    <div class="repo-detail__not-found">
+      <h1>Repositorio no encontrado</h1>
+      <p>El repositorio solicitado no existe o ha sido eliminado.</p>
+      <a routerLink="/repositorios" class="repo-detail__cta">Ver todos los repositorios</a>
+    </div>
+  } @else if (repository(); as r) {
+    <header class="repo-detail__hero">
+      <div
+        class="repo-detail__badge-stage"
+        (mousemove)="onBadgeMove($event)"
+        (mouseleave)="onBadgeLeave()"
+      >
+        <div
+          class="repo-detail__badge"
+          [style.background-color]="languageColor()"
+          [style.transform]="
+            'rotateX(' + tilt().x + 'deg) rotateY(' + tilt().y + 'deg) scale(' + tilt().scale + ')'
+          "
+          aria-hidden="true"
+        >
+          <svg viewBox="0 0 24 24" focusable="false">
+            <path
+              d="M9.4 16.6 4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0L19.2 12l-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+      </div>
+
+      <div class="repo-detail__identity">
+        <p class="repo-detail__eyebrow">
+          <a
+            class="repo-detail__lang"
+            routerLink="/repositorios"
+            [queryParams]="{ language: r.language }"
+            [style.--lang-tint]="languageColor()"
+            [attr.aria-label]="'Filtrar repositorios por ' + r.language"
+          >
+            <span class="repo-detail__lang-dot" aria-hidden="true"></span>
+            {{ r.language }}
+          </a>
+        </p>
+        <h1 class="repo-detail__name">{{ r.name }}</h1>
+        <p class="repo-detail__description">{{ r.description }}</p>
+
+        <ul class="repo-detail__meta">
+          <li class="repo-detail__meta-item">
+            @if (owner(); as o) {
+              <a
+                [routerLink]="['/usuarios', o.id]"
+                class="repo-detail__owner-link"
+                [attr.aria-label]="'Ver perfil de ' + o.name"
+              >
+                @if (avatarFailed()) {
+                  <span
+                    class="repo-detail__owner-avatar repo-detail__owner-avatar--initials"
+                    aria-hidden="true"
+                  >
+                    {{ ownerInitials() }}
+                  </span>
+                } @else {
+                  <img
+                    class="repo-detail__owner-avatar"
+                    [src]="o.avatarUrl"
+                    [alt]=""
+                    width="32"
+                    height="32"
+                    decoding="async"
+                    (error)="onAvatarError()"
+                  />
+                }
+                <span class="repo-detail__owner-name">{{ o.name }}</span>
+              </a>
+            } @else {
+              <span class="repo-detail__owner-unknown">Propietario desconocido</span>
+            }
+          </li>
+          <li class="repo-detail__meta-item repo-detail__meta-item--static">
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path
+                d="M7 2a1 1 0 0 1 1 1v1h8V3a1 1 0 1 1 2 0v1h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2V3a1 1 0 0 1 1-1zm13 8H4v10h16V10zM4 8h16V6h-2v1a1 1 0 1 1-2 0V6H8v1a1 1 0 1 1-2 0V6H4v2z"
+                fill="currentColor"
+              />
+            </svg>
+            <time [attr.datetime]="r.createdAt">{{ createdAtLabel() }}</time>
+          </li>
+          <li class="repo-detail__meta-item">
+            <span class="repo-detail__stars repo-detail__stars--{{ starsTier() }}">
+              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path
+                  d="M12 2.5l2.95 5.97 6.59.96-4.77 4.65 1.13 6.56L12 17.55l-5.9 3.09 1.13-6.56-4.77-4.65 6.59-.96L12 2.5z"
+                  fill="currentColor"
+                />
+              </svg>
+              {{ starsLabel() }}
+            </span>
+          </li>
+        </ul>
+      </div>
+    </header>
+
+    @if (otherReposBySameOwner().length > 0 && owner(); as o) {
+      <section class="repo-detail__section" aria-labelledby="repo-detail-owner-title">
+        <h2 id="repo-detail-owner-title" class="repo-detail__section-title">
+          Otros repositorios de {{ o.name }}
+        </h2>
+        <div class="repo-detail__rail-wrapper">
+          <button
+            type="button"
+            class="repo-detail__rail-arrow repo-detail__rail-arrow--prev"
+            (click)="scrollOwnerPrev()"
+            [disabled]="!canScrollOwnerPrev()"
+            aria-label="Ver repositorios anteriores"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path
+                d="M15 18l-6-6 6-6"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2.25"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
+          <ul
+            #ownerRailEl
+            class="repo-detail__rail"
+            aria-label="Otros repositorios del propietario"
+            (scroll)="onOwnerRailScroll()"
+          >
+            @for (repo of otherReposBySameOwner(); track repo.id) {
+              <li class="repo-detail__rail-item">
+                <a
+                  [routerLink]="['/repositorios', repo.id]"
+                  class="other-repo"
+                  [attr.aria-label]="'Ver detalle de ' + repo.name"
+                >
+                  <div
+                    class="other-repo__badge"
+                    [style.background-color]="colorOf(repo)"
+                    aria-hidden="true"
+                  >
+                    <svg viewBox="0 0 24 24" focusable="false">
+                      <path
+                        d="M9.4 16.6 4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0L19.2 12l-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </div>
+                  <span class="other-repo__name">{{ repo.name }}</span>
+                  <span class="other-repo__description">{{ repo.description }}</span>
+                  <span class="other-repo__stars other-repo__stars--{{ tierOf(repo) }}">
+                    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                      <path
+                        d="M12 2.5l2.95 5.97 6.59.96-4.77 4.65 1.13 6.56L12 17.55l-5.9 3.09 1.13-6.56-4.77-4.65 6.59-.96L12 2.5z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                    {{ repo.stars }}
+                  </span>
+                </a>
+              </li>
+            }
+          </ul>
+          <button
+            type="button"
+            class="repo-detail__rail-arrow repo-detail__rail-arrow--next"
+            (click)="scrollOwnerNext()"
+            [disabled]="!canScrollOwnerNext()"
+            aria-label="Ver más repositorios"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path
+                d="M9 6l6 6-6 6"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2.25"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
+        </div>
+      </section>
+    }
+
+    @if (similarByLanguage().length > 0) {
+      <section class="repo-detail__section" aria-labelledby="repo-detail-lang-title">
+        <h2 id="repo-detail-lang-title" class="repo-detail__section-title">
+          Repositorios similares en {{ r.language }}
+        </h2>
+        <div class="repo-detail__rail-wrapper">
+          <button
+            type="button"
+            class="repo-detail__rail-arrow repo-detail__rail-arrow--prev"
+            (click)="scrollLangPrev()"
+            [disabled]="!canScrollLangPrev()"
+            aria-label="Ver repositorios anteriores"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path
+                d="M15 18l-6-6 6-6"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2.25"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
+          <ul
+            #langRailEl
+            class="repo-detail__rail"
+            aria-label="Repositorios similares en el mismo lenguaje"
+            (scroll)="onLangRailScroll()"
+          >
+            @for (repo of similarByLanguage(); track repo.id) {
+              <li class="repo-detail__rail-item">
+                <a
+                  [routerLink]="['/repositorios', repo.id]"
+                  class="other-repo"
+                  [attr.aria-label]="'Ver detalle de ' + repo.name"
+                >
+                  <div
+                    class="other-repo__badge"
+                    [style.background-color]="colorOf(repo)"
+                    aria-hidden="true"
+                  >
+                    <svg viewBox="0 0 24 24" focusable="false">
+                      <path
+                        d="M9.4 16.6 4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0L19.2 12l-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </div>
+                  <span class="other-repo__name">{{ repo.name }}</span>
+                  <span class="other-repo__description">{{ repo.description }}</span>
+                  @if (ownerOf(repo); as o) {
+                    <span class="other-repo__owner">
+                      <img
+                        class="other-repo__owner-avatar"
+                        [src]="o.avatarUrl"
+                        [alt]=""
+                        width="16"
+                        height="16"
+                        loading="lazy"
+                        decoding="async"
+                      />
+                      <span class="other-repo__owner-name">{{ o.name }}</span>
+                    </span>
+                  }
+                  <span class="other-repo__stars other-repo__stars--{{ tierOf(repo) }}">
+                    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                      <path
+                        d="M12 2.5l2.95 5.97 6.59.96-4.77 4.65 1.13 6.56L12 17.55l-5.9 3.09 1.13-6.56-4.77-4.65 6.59-.96L12 2.5z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                    {{ repo.stars }}
+                  </span>
+                </a>
+              </li>
+            }
+          </ul>
+          <button
+            type="button"
+            class="repo-detail__rail-arrow repo-detail__rail-arrow--next"
+            (click)="scrollLangNext()"
+            [disabled]="!canScrollLangNext()"
+            aria-label="Ver más repositorios"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path
+                d="M9 6l6 6-6 6"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2.25"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
+        </div>
+      </section>
+    }
+  }
+</section>

--- a/src/app/features/repositories/repository-detail-page.ts
+++ b/src/app/features/repositories/repository-detail-page.ts
@@ -1,0 +1,257 @@
+import {
+  afterNextRender,
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  type ElementRef,
+  inject,
+  input,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { RouterLink } from '@angular/router';
+
+import { Users } from '@features/users';
+import type { User } from '@features/users/user';
+import { Repositories } from './repositories';
+import type { Repository } from './repository';
+
+/**
+ * Paleta canónica de colores de lenguaje (alineada con `RepositoryCard`).
+ */
+const LANGUAGE_COLOR: Readonly<Record<string, string>> = {
+  TypeScript: '#3178c6',
+  JavaScript: '#f1e05a',
+  Python: '#3572a5',
+  Java: '#b07219',
+  Go: '#00add8',
+  Rust: '#dea584',
+  'C#': '#178600',
+  'C++': '#f34b7d',
+  Ruby: '#701516',
+  Swift: '#f05138',
+  Kotlin: '#a97bff',
+  HTML: '#e34c26',
+  CSS: '#563d7c',
+  Shell: '#89e051',
+  YAML: '#cb171e',
+};
+
+const FALLBACK_LANGUAGE_COLOR = '#73726d';
+
+const DATE_FORMATTER = new Intl.DateTimeFormat('es-CO', {
+  day: 'numeric',
+  month: 'long',
+  year: 'numeric',
+});
+
+interface BadgeTilt {
+  readonly x: number;
+  readonly y: number;
+  readonly scale: number;
+}
+
+const BADGE_REST: BadgeTilt = { x: 0, y: 0, scale: 1 };
+const BADGE_MAX_TILT_DEG = 14;
+const BADGE_MAX_SCALE = 1.18;
+const BADGE_MIN_SCALE = 1.06;
+
+type StarsTier = 'low' | 'mid' | 'high' | 'top';
+
+function tierForStars(stars: number): StarsTier {
+  if (stars >= 120) return 'top';
+  if (stars >= 80) return 'high';
+  if (stars >= 40) return 'mid';
+  return 'low';
+}
+
+@Component({
+  selector: 'app-repository-detail-page',
+  imports: [RouterLink],
+  templateUrl: './repository-detail-page.html',
+  styleUrl: './repository-detail-page.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RepositoryDetailPage {
+  /** Bound from the route param `:id` thanks to `withComponentInputBinding()`. */
+  readonly id = input.required<string>();
+
+  private readonly reposService = inject(Repositories);
+  private readonly usersService = inject(Users);
+
+  protected readonly avatarFailed = signal(false);
+  protected readonly tilt = signal<BadgeTilt>(BADGE_REST);
+
+  private readonly allRepos = toSignal(this.reposService.list(), { initialValue: undefined });
+  private readonly allUsers = toSignal(this.usersService.list(), { initialValue: undefined });
+
+  protected readonly isLoading = computed(
+    () => this.allRepos() === undefined || this.allUsers() === undefined,
+  );
+
+  protected readonly repository = computed<Repository | undefined>(() => {
+    const list = this.allRepos();
+    if (!list) return undefined;
+    const numeric = Number(this.id());
+    return list.find((r) => r.id === numeric);
+  });
+
+  protected readonly notFound = computed(
+    () => this.allRepos() !== undefined && this.repository() === undefined,
+  );
+
+  protected readonly owner = computed<User | null>(() => {
+    const r = this.repository();
+    const list = this.allUsers();
+    if (!r || !list) return null;
+    return list.find((u) => u.id === r.ownerId) ?? null;
+  });
+
+  protected readonly otherReposBySameOwner = computed<readonly Repository[]>(() => {
+    const list = this.allRepos();
+    const r = this.repository();
+    if (!list || !r) return [];
+    return list.filter((other) => other.id !== r.id && other.ownerId === r.ownerId);
+  });
+
+  protected readonly similarByLanguage = computed<readonly Repository[]>(() => {
+    const list = this.allRepos();
+    const r = this.repository();
+    if (!list || !r) return [];
+    return list.filter((other) => other.id !== r.id && other.language === r.language);
+  });
+
+  protected readonly languageColor = computed(() => {
+    const r = this.repository();
+    if (!r) return FALLBACK_LANGUAGE_COLOR;
+    return LANGUAGE_COLOR[r.language] ?? FALLBACK_LANGUAGE_COLOR;
+  });
+
+  protected readonly createdAtLabel = computed(() => {
+    const r = this.repository();
+    return r ? DATE_FORMATTER.format(r.createdAtDate) : '';
+  });
+
+  protected readonly starsLabel = computed(() => {
+    const r = this.repository();
+    if (!r) return '';
+    const n = r.stars;
+    if (n === 1) return '1 estrellita';
+    return `${String(n)} estrellitas`;
+  });
+
+  protected readonly starsTier = computed<StarsTier>(() => {
+    const r = this.repository();
+    if (!r) return 'low';
+    return tierForStars(r.stars);
+  });
+
+  protected readonly ownerInitials = computed(() => {
+    const o = this.owner();
+    if (!o) return '?';
+    const parts = o.name.trim().split(/\s+/).filter(Boolean);
+    const first = parts[0]?.[0] ?? '';
+    const last = parts.length > 1 ? (parts[parts.length - 1]?.[0] ?? '') : '';
+    return (first + last).toUpperCase() || '?';
+  });
+
+  /* ── Rails: control programático con flechas ───────────────────────── */
+  private readonly ownerRailEl = viewChild<ElementRef<HTMLElement>>('ownerRailEl');
+  private readonly langRailEl = viewChild<ElementRef<HTMLElement>>('langRailEl');
+
+  protected readonly canScrollOwnerPrev = signal(false);
+  protected readonly canScrollOwnerNext = signal(false);
+  protected readonly canScrollLangPrev = signal(false);
+  protected readonly canScrollLangNext = signal(false);
+
+  constructor() {
+    afterNextRender(() => {
+      this.recomputeRailState(this.ownerRailEl()?.nativeElement, 'owner');
+      this.recomputeRailState(this.langRailEl()?.nativeElement, 'lang');
+    });
+  }
+
+  /* Helpers para los mini-cards de los rails. */
+  protected colorOf(repo: Repository): string {
+    return LANGUAGE_COLOR[repo.language] ?? FALLBACK_LANGUAGE_COLOR;
+  }
+
+  protected tierOf(repo: Repository): StarsTier {
+    return tierForStars(repo.stars);
+  }
+
+  /** Resuelve el `User` propietario de un repo del rail (puede ser null
+   *  si el dataset de usuarios aún no cargó o no contiene ese ownerId). */
+  protected ownerOf(repo: Repository): User | null {
+    return this.allUsers()?.find((u) => u.id === repo.ownerId) ?? null;
+  }
+
+  protected onAvatarError(): void {
+    this.avatarFailed.set(true);
+  }
+
+  protected onBadgeMove(event: MouseEvent): void {
+    const stage = event.currentTarget as HTMLElement;
+    const rect = stage.getBoundingClientRect();
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
+    const nx = (event.clientX - cx) / (rect.width / 2);
+    const ny = (event.clientY - cy) / (rect.height / 2);
+    const dist = Math.min(1, Math.hypot(nx, ny));
+    const scale = BADGE_MAX_SCALE - (BADGE_MAX_SCALE - BADGE_MIN_SCALE) * dist;
+    this.tilt.set({
+      x: -ny * BADGE_MAX_TILT_DEG,
+      y: nx * BADGE_MAX_TILT_DEG,
+      scale,
+    });
+  }
+
+  protected onBadgeLeave(): void {
+    this.tilt.set(BADGE_REST);
+  }
+
+  protected onOwnerRailScroll(): void {
+    this.recomputeRailState(this.ownerRailEl()?.nativeElement, 'owner');
+  }
+
+  protected onLangRailScroll(): void {
+    this.recomputeRailState(this.langRailEl()?.nativeElement, 'lang');
+  }
+
+  protected scrollOwnerPrev(): void {
+    this.scrollRail(this.ownerRailEl()?.nativeElement, -1);
+  }
+
+  protected scrollOwnerNext(): void {
+    this.scrollRail(this.ownerRailEl()?.nativeElement, 1);
+  }
+
+  protected scrollLangPrev(): void {
+    this.scrollRail(this.langRailEl()?.nativeElement, -1);
+  }
+
+  protected scrollLangNext(): void {
+    this.scrollRail(this.langRailEl()?.nativeElement, 1);
+  }
+
+  private scrollRail(el: HTMLElement | undefined, direction: -1 | 1): void {
+    if (!el) return;
+    const delta = el.clientWidth * 0.8 * direction;
+    el.scrollBy({ left: delta, behavior: 'smooth' });
+  }
+
+  private recomputeRailState(el: HTMLElement | undefined, rail: 'owner' | 'lang'): void {
+    if (!el) return;
+    const max = el.scrollWidth - el.clientWidth;
+    const canPrev = el.scrollLeft > 0;
+    const canNext = max > 0 && el.scrollLeft < max - 1;
+    if (rail === 'owner') {
+      this.canScrollOwnerPrev.set(canPrev);
+      this.canScrollOwnerNext.set(canNext);
+    } else {
+      this.canScrollLangPrev.set(canPrev);
+      this.canScrollLangNext.set(canNext);
+    }
+  }
+}

--- a/src/app/features/users/user-detail-page.html
+++ b/src/app/features/users/user-detail-page.html
@@ -75,12 +75,14 @@
 
       <div class="user-detail__identity">
         <p class="user-detail__eyebrow">
-          <span
+          <a
             class="user-detail__role user-detail__role--{{ u.role }}"
-            [attr.aria-label]="'Rol: ' + roleLabel()"
+            routerLink="/usuarios"
+            [queryParams]="{ role: u.role }"
+            [attr.aria-label]="'Filtrar usuarios por rol ' + roleLabel()"
           >
             {{ roleLabel() }}
-          </span>
+          </a>
         </p>
         <h1 class="user-detail__name">{{ u.name }}</h1>
         <p class="user-detail__username">&#64;{{ u.username }}</p>

--- a/src/app/features/users/users-page.ts
+++ b/src/app/features/users/users-page.ts
@@ -8,6 +8,7 @@ import {
   untracked,
 } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute } from '@angular/router';
 import { debounceTime, distinctUntilChanged } from 'rxjs';
 
 import { UserCard } from '@shared/ui/user-card/user-card';
@@ -23,6 +24,8 @@ import {
 import { Users } from './users';
 import type { Role, UserFilters } from './user';
 
+const VALID_ROLES = new Set<Role>(['admin', 'developer', 'designer']);
+
 @Component({
   selector: 'app-users-page',
   imports: [UserCard, Paginator, FilterToolbar, SearchInputField, ChipsField, SelectField],
@@ -32,9 +35,19 @@ import type { Role, UserFilters } from './user';
 })
 export class UsersPage {
   private readonly usersService = inject(Users);
+  private readonly route = inject(ActivatedRoute);
 
   protected readonly title = 'Usuarios';
   protected readonly pageSize = 6;
+
+  /**
+   * Query params leídos reactivamente desde `ActivatedRoute`. Pre-aplica
+   * los filtros internos cuando se entra con `?role=:name` (desde el chip
+   * de rol de un `UserCard`).
+   */
+  private readonly queryParams = toSignal(this.route.queryParamMap, {
+    initialValue: this.route.snapshot.queryParamMap,
+  });
 
   /* ── Estado de filtros ─────────────────────────────────────────────── */
   protected readonly query = signal('');
@@ -108,6 +121,19 @@ export class UsersPage {
   protected readonly skeletonSlots = Array.from({ length: this.pageSize }, (_, i) => i);
 
   constructor() {
+    /* Cuando se entra desde otra página con `?role=:name` (chip de rol de
+       un UserCard), sincroniza el query param al filtro interno. Validamos
+       contra `VALID_ROLES` para descartar valores arbitrarios de la URL. */
+    effect(() => {
+      const params = this.queryParams();
+      const roleParam = params.get('role');
+      untracked(() => {
+        if (roleParam !== null && VALID_ROLES.has(roleParam as Role) && this.role() !== roleParam) {
+          this.role.set(roleParam as Role);
+        }
+      });
+    });
+
     /* Cualquier cambio en filtros nos devuelve a la página 1. */
     effect(() => {
       this.filters();

--- a/src/app/shared/ui/repository-card/repository-card.css
+++ b/src/app/shared/ui/repository-card/repository-card.css
@@ -4,6 +4,7 @@
 }
 
 .repo-card {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
@@ -13,10 +14,45 @@
   border: 1px solid var(--color-border);
   border-radius: 0.75rem;
   box-shadow: 0 1px 2px rgba(25, 25, 22, 0.04);
+  /* La card entera es clickeable (overlay link) → cursor pointer global. */
+  cursor: pointer;
   transition:
     transform 220ms cubic-bezier(0.2, 0, 0, 1),
     box-shadow 220ms cubic-bezier(0.2, 0, 0, 1),
     border-color 220ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+/* Overlay link: cubre toda la card → click navega al detalle. Los wrappers
+   internos (header/meta/footer) tienen `pointer-events: none` para dejar
+   pasar el click; los interactivos verdaderos (badge-stage para el tilt,
+   owner-link → /usuarios/:id) re-activan `pointer-events: auto` con
+   `z-index` superior para conservar su propia interacción. */
+.repo-card__link {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  border-radius: inherit;
+}
+
+.repo-card__link:focus-visible {
+  outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
+  outline-offset: 2px;
+}
+
+.repo-card__header,
+.repo-card__meta,
+.repo-card__footer {
+  position: relative;
+  z-index: 2;
+  pointer-events: none;
+}
+
+.repo-card__owner-link,
+.repo-card__badge-stage,
+.repo-card__lang {
+  position: relative;
+  z-index: 3;
+  pointer-events: auto;
 }
 
 .repo-card:hover,
@@ -114,21 +150,56 @@
 }
 
 /* ── Language chip ───────────────────────────────────────────────────── */
-.repo-card__lang {
+.repo-card__lang,
+.repo-card__lang:visited {
   align-self: start;
   display: inline-flex;
   align-items: center;
   gap: 0.375rem;
   font-size: 0.6875rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
+  font-weight: 700;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
-  padding: 0.25rem 0.5rem;
+  padding: 0.3125rem 0.625rem 0.3125rem 0.5rem;
   border-radius: 999px;
-  background: var(--c-uniandes-color-neutro-30);
+  /* Gradiente teñido por el lenguaje (`--lang-tint` lo setea el componente
+     vía `[style.--lang-tint]="languageColor()"`). Mezclamos con `transparent`
+     a 10/22% de alpha → fondo sutil que conserva legibilidad del texto. */
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--lang-tint, var(--c-uniandes-color-neutro-50)) 10%, transparent) 0%,
+    color-mix(in srgb, var(--lang-tint, var(--c-uniandes-color-neutro-50)) 22%, transparent) 100%
+  );
   color: var(--color-text);
-  border: 1px solid var(--color-border);
+  border: 1px solid color-mix(in srgb, var(--lang-tint, var(--color-border)) 40%, transparent);
   white-space: nowrap;
+  text-decoration: none;
+  /* Anillo arranca en 0 y aparece con overshoot suave en hover. */
+  box-shadow: 0 0 0 0 transparent;
+  transition:
+    box-shadow 280ms cubic-bezier(0.34, 1.4, 0.64, 1),
+    transform 200ms cubic-bezier(0.2, 0, 0, 1),
+    border-color 200ms ease,
+    filter 200ms ease;
+}
+
+.repo-card__lang:hover,
+.repo-card__lang:focus-visible {
+  /* Halo en el color del lenguaje (35% de --lang-tint sobre transparent). */
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--lang-tint, var(--color-border)) 35%, transparent);
+  transform: translateY(-1px);
+  filter: brightness(0.97);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .repo-card__lang {
+    transition: none;
+  }
+  .repo-card__lang:hover,
+  .repo-card__lang:focus-visible {
+    transform: none;
+    filter: none;
+  }
 }
 
 .repo-card__lang-dot {
@@ -136,6 +207,9 @@
   height: 0.5rem;
   border-radius: 50%;
   display: inline-block;
+  /* El dot a opacidad completa contrasta con el bg tintado al 10–22%. */
+  background: var(--lang-tint, currentColor);
+  flex-shrink: 0;
 }
 
 /* ── Meta (owner + created) ──────────────────────────────────────────── */

--- a/src/app/shared/ui/repository-card/repository-card.html
+++ b/src/app/shared/ui/repository-card/repository-card.html
@@ -1,4 +1,9 @@
 <article class="repo-card" [attr.aria-labelledby]="'repo-' + repository().id + '-name'">
+  <a
+    class="repo-card__link"
+    [routerLink]="['/repositorios', repository().id]"
+    [attr.aria-label]="'Ver detalle de ' + repository().name"
+  ></a>
   <header class="repo-card__header">
     <div
       class="repo-card__badge-stage"
@@ -27,14 +32,16 @@
       </h3>
       <p class="repo-card__description">{{ repository().description }}</p>
     </div>
-    <span class="repo-card__lang" [attr.aria-label]="'Lenguaje: ' + repository().language">
-      <span
-        class="repo-card__lang-dot"
-        [style.background-color]="languageColor()"
-        aria-hidden="true"
-      ></span>
+    <a
+      class="repo-card__lang"
+      routerLink="/repositorios"
+      [queryParams]="{ language: repository().language }"
+      [style.--lang-tint]="languageColor()"
+      [attr.aria-label]="'Filtrar repositorios por ' + repository().language"
+    >
+      <span class="repo-card__lang-dot" aria-hidden="true"></span>
       {{ repository().language }}
-    </span>
+    </a>
   </header>
 
   <dl class="repo-card__meta">

--- a/src/app/shared/ui/user-card/user-card.css
+++ b/src/app/shared/ui/user-card/user-card.css
@@ -52,7 +52,8 @@
 .user-card__location,
 .user-card__email,
 .user-card__avatar-stage,
-.user-card__repos {
+.user-card__repos,
+.user-card__role {
   position: relative;
   z-index: 3;
   pointer-events: auto;
@@ -165,34 +166,97 @@
 }
 
 /* ── Role chip ───────────────────────────────────────────────────────── */
-.user-card__role {
+.user-card__role,
+.user-card__role:visited {
   align-self: start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
   font-size: 0.6875rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
+  font-weight: 700;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
-  padding: 0.25rem 0.5rem;
+  padding: 0.3125rem 0.625rem 0.3125rem 0.5rem;
   border-radius: 999px;
   border: 1px solid transparent;
   white-space: nowrap;
+  text-decoration: none;
+  /* `box-shadow` arranca en 0 transparente y se anima a un anillo en hover.
+     `cubic-bezier(0.34, 1.4, 0.64, 1)` da un ligero overshoot al aparecer
+     el anillo, como si "pop"-eara desde el chip. */
+  box-shadow: 0 0 0 0 transparent;
+  transition:
+    box-shadow 280ms cubic-bezier(0.34, 1.4, 0.64, 1),
+    transform 200ms cubic-bezier(0.2, 0, 0, 1),
+    border-color 200ms ease,
+    filter 200ms ease;
 }
 
-.user-card__role--admin {
-  background: var(--c-uniandes-color-secondary-02-lightbg);
+/* Glyph circular pequeño antes del label — refuerza identidad visual del rol. */
+.user-card__role::before {
+  content: '';
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.65;
+  flex-shrink: 0;
+}
+
+.user-card__role:hover,
+.user-card__role:focus-visible {
+  box-shadow: 0 0 0 4px var(--user-card-role-ring, transparent);
+  transform: translateY(-1px);
+  filter: brightness(0.97);
+}
+
+.user-card__role:hover::before,
+.user-card__role:focus-visible::before {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .user-card__role {
+    transition: none;
+  }
+  .user-card__role:hover,
+  .user-card__role:focus-visible {
+    transform: none;
+    filter: none;
+  }
+}
+
+/* ── Variantes por rol con gradiente sutil + halo de hover propio ────── */
+.user-card__role--admin,
+.user-card__role--admin:visited {
+  background: linear-gradient(
+    135deg,
+    var(--c-uniandes-color-secondary-02-lightbg) 0%,
+    #ffd840 100%
+  );
   color: var(--c-uniandes-color-primarytext-lightbg);
   border-color: var(--c-uniandes-color-secondary-01-lightbg);
+  --user-card-role-ring: rgba(255, 228, 30, 0.45);
 }
 
-.user-card__role--developer {
-  background: var(--c-uniandes-color-neutro-30);
+.user-card__role--developer,
+.user-card__role--developer:visited {
+  background: linear-gradient(
+    135deg,
+    var(--c-uniandes-color-neutro-30) 0%,
+    var(--c-uniandes-color-neutro-40) 100%
+  );
   color: var(--c-uniandes-color-primarytext-lightbg);
-  border-color: var(--color-border);
+  border-color: var(--c-uniandes-color-neutro-50);
+  --user-card-role-ring: rgba(138, 137, 132, 0.35);
 }
 
-.user-card__role--designer {
-  background: rgba(36, 66, 178, 0.08);
+.user-card__role--designer,
+.user-card__role--designer:visited {
+  background: linear-gradient(135deg, rgba(36, 66, 178, 0.08) 0%, rgba(36, 66, 178, 0.18) 100%);
   color: var(--color-accent);
-  border-color: rgba(36, 66, 178, 0.25);
+  border-color: rgba(36, 66, 178, 0.35);
+  --user-card-role-ring: rgba(36, 66, 178, 0.3);
 }
 
 /* ── Meta (location + email) ─────────────────────────────────────────── */

--- a/src/app/shared/ui/user-card/user-card.html
+++ b/src/app/shared/ui/user-card/user-card.html
@@ -40,12 +40,14 @@
       <h3 [id]="'user-' + user().id + '-name'" class="user-card__name">{{ user().name }}</h3>
       <p class="user-card__username">&#64;{{ user().username }}</p>
     </div>
-    <span
+    <a
       class="user-card__role user-card__role--{{ user().role }}"
-      [attr.aria-label]="'Rol: ' + roleLabel()"
+      routerLink="/usuarios"
+      [queryParams]="{ role: user().role }"
+      [attr.aria-label]="'Filtrar usuarios por rol ' + roleLabel()"
     >
       {{ roleLabel() }}
-    </span>
+    </a>
   </header>
 
   <dl class="user-card__meta">

--- a/src/styles.css
+++ b/src/styles.css
@@ -111,6 +111,21 @@
   box-sizing: border-box;
 }
 
+html {
+  /* Hace que el `scrollTo(0, 0)` que dispara
+     `withInMemoryScrolling({ scrollPositionRestoration: 'enabled' })` al
+     navegar entre rutas anime suavemente en vez de hacer un jump instantáneo.
+     También aplica a anclas y a cualquier scroll programático sin
+     `behavior` explícito. */
+  scroll-behavior: smooth;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
 html,
 body {
   margin: 0;


### PR DESCRIPTION
## Summary

Implementa la HU "Detalle de Repositorio" + extiende el patrón de cross-feature deep linking a los chips de rol y lenguaje de cards y heroes, y añade scroll suave entre navegaciones.

### Vista `/repositorios/:id`
- **Hero**: badge cuadrado grande de lenguaje (clamp 7-10rem) coloreado con paleta GitHub linguist + tilt 3D + escala dinámica, h1 con franja amarilla Uniandes permanente, descripción, propietario (avatar mini + nombre → `/usuarios/:ownerId`), fecha de creación en `es-CO`, badge de **estrellitas** con 4 tiers cromáticos.
- **Sección "Otros repositorios de {owner.name}"**: rail horizontal con flechas prev/next, scrollbar nativo oculto, mini-cards (`.other-repo`, 14rem) con badge mini, nombre, descripción line-clamped a 2 líneas y chip de estrellitas con tier color.
- **Sección "Repositorios similares en {language}"**: mismo formato + **avatar mini + nombre del propietario** (rail puede mostrar repos de cualquier owner).
- En viewports estrechos (≤640px) un rail con una sola card aislada (`:only-child`) se estira al 100% del wrapper en lugar de quedar a 14rem; rails con varias cards mantienen el carrusel deslizable.
- Back link, skeleton del hero durante carga, estado "Repositorio no encontrado" con CTA.

### Cross-feature deep linking
- **`RepositoryCard` overlay link**: toda la card navega a `/repositorios/:id` via `<a class=\"repo-card__link\">` con `pointer-events`/z-index orchestration que preserva los interactivos internos (badge tilt, owner link a `/usuarios/:id`, chip de lenguaje).
- **Chip de rol del UserCard y del hero de UserDetailPage** → `/usuarios?role=:role`.
- **Chip de lenguaje del RepositoryCard y del hero de RepositoryDetailPage** → `/repositorios?language=:name`.
- `UsersPage` y `RepositoriesPage` leen query params reactivamente vía `ActivatedRoute.queryParamMap` envuelto con `toSignal` (mismo patrón de `?owner=:id` ya existente). Effect de constructor sincroniza al filtro interno con validación contra el set de roles válidos en el caso de `UsersPage`.

### Polish visual de los chips
- **Chips de rol** (UserCard + UserDetailPage hero): gradiente 135° per-rol, glyph circular `::before` en `currentColor`, halo en hover via `--user-card-role-ring` / `--user-detail-role-ring` (amarillo/grafito/azul) con `cubic-bezier(0.34, 1.4, 0.64, 1)` overshoot.
- **Chips de lenguaje** (RepositoryCard + RepositoryDetailPage hero): gradiente y halo dinámicos via `--lang-tint` CSS custom property alimentada por `[style.--lang-tint]=\"languageColor()\"`. Uso de `color-mix(in srgb, var(--lang-tint) X%, transparent)` para tintar bg, borde y ring sin definir 15 reglas separadas.
- `prefers-reduced-motion: reduce` cancela `transition`/`transform`/`filter` en todos los chips.

### Scroll suave entre navegaciones
- `provideRouter` ahora usa `withInMemoryScrolling({ scrollPositionRestoration: 'enabled' })` → en cada forward nav (e.g., card click → detalle) hace scroll al top; en back/forward del browser restaura posición previa.
- `html { scroll-behavior: smooth }` en `src/styles.css` con fallback a `auto` bajo `prefers-reduced-motion: reduce`.

### Routing y prerender
- Nueva ruta `/repositorios/:id` lazy + entrada en `app.routes.server.ts` con `getPrerenderParams` que fetch'ea `environment.apis.repositories` para enumerar los 30 ids. El build prerenderiza ahora **63 rutas estáticas** (3 base + 30 user details + 30 repo details).

## Test plan
- [x] `npm run typecheck`, `npm run lint`, `npm run format:check`, `npx ng test --watch=false`, `npm run build` (todos en verde local).
- [ ] `docker compose -f docker-compose.dev.yml up` → abrir `/repositorios`.
- [ ] Click en cualquier card → navega a `/repositorios/:id`. Hero, owner clickeable, fecha en `es-CO`, badge de estrellitas con tier color (low/mid/high/top según rangos del JSON).
- [ ] Rails: las flechas avanzan ~80% del viewport con scroll smooth; los items se ocultan al alcanzar inicio/fin; en móvil con un solo elemento la card se estira al 100%.
- [ ] Click en chip de lenguaje del hero → `/repositorios?language=:lang` con SelectField mostrando el lenguaje seleccionado y filtro aplicado.
- [ ] Click en chip de lenguaje de un `RepositoryCard` → mismo deep linking.
- [ ] Click en chip de rol de un `UserCard` o del hero de detalle de usuario → `/usuarios?role=:role`.
- [ ] Hover sobre cualquier chip de rol/lenguaje → halo de color overshooting + lift sutil.
- [ ] Scroll abajo en `/usuarios` o `/repositorios`, click en una card → la vista de detalle entra desde el top con animación suave (no jump). Back-button restaura posición previa.
- [ ] `prefers-reduced-motion: reduce` deshabilita tilt, halos animados y scroll smooth.

## Commits
- `02616c4` — `feat(repositories): repository detail page + role/language deep linking`