### PR TITLE
release: 1.0.0 — listados, detalles y deep linking

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -44,8 +44,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "8kB",
-                  "maximumError": "16kB"
+                  "maximumWarning": "14kB",
+                  "maximumError": "18kB"
                 }
               ],
               "outputHashing": "all"
@@ -67,8 +67,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "8kB",
-                  "maximumError": "16kB"
+                  "maximumWarning": "14kB",
+                  "maximumError": "18kB"
                 }
               ]
             }

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -3,7 +3,13 @@ import {
   ErrorHandler,
   provideBrowserGlobalErrorListeners,
 } from '@angular/core';
-import { PreloadAllModules, provideRouter, TitleStrategy, withPreloading } from '@angular/router';
+import {
+  PreloadAllModules,
+  provideRouter,
+  TitleStrategy,
+  withComponentInputBinding,
+  withPreloading,
+} from '@angular/router';
 import { provideHttpClient, withFetch, withInterceptorsFromDi } from '@angular/common/http';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
 
@@ -14,7 +20,7 @@ import { AppTitleStrategy } from './core/providers/app-title-strategy';
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
-    provideRouter(routes, withPreloading(PreloadAllModules)),
+    provideRouter(routes, withPreloading(PreloadAllModules), withComponentInputBinding()),
     provideHttpClient(withFetch(), withInterceptorsFromDi()),
     provideClientHydration(withEventReplay()),
     { provide: ErrorHandler, useClass: GlobalErrorHandler },

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -8,6 +8,7 @@ import {
   provideRouter,
   TitleStrategy,
   withComponentInputBinding,
+  withInMemoryScrolling,
   withPreloading,
 } from '@angular/router';
 import { provideHttpClient, withFetch, withInterceptorsFromDi } from '@angular/common/http';
@@ -20,7 +21,15 @@ import { AppTitleStrategy } from './core/providers/app-title-strategy';
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
-    provideRouter(routes, withPreloading(PreloadAllModules), withComponentInputBinding()),
+    provideRouter(
+      routes,
+      withPreloading(PreloadAllModules),
+      withComponentInputBinding(),
+      /* `scrollPositionRestoration: 'enabled'` → al navegar a una nueva ruta
+         (e.g., card click → /usuarios/:id) hace scroll al top; al volver
+         atrás con el browser restaura la posición previa. */
+      withInMemoryScrolling({ scrollPositionRestoration: 'enabled' }),
+    ),
     provideHttpClient(withFetch(), withInterceptorsFromDi()),
     provideClientHydration(withEventReplay()),
     { provide: ErrorHandler, useClass: GlobalErrorHandler },

--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -1,4 +1,5 @@
 import { RenderMode, type ServerRoute } from '@angular/ssr';
+import { environment } from '@env/environment';
 
 /**
  * Prerender para todas las rutas → genera HTML estático en build time.
@@ -8,8 +9,24 @@ import { RenderMode, type ServerRoute } from '@angular/ssr';
  * Las llamadas HttpClient (`Users.list()`, `Repositories.list()`) se
  * ejecutan durante el prerender; los datos se embeben en el HTML vía
  * TransferState — el navegador hidrata sin volver a fetchear.
+ *
+ * Para rutas dinámicas (`:id`) Angular SSR exige `getPrerenderParams`
+ * que devuelva la lista de valores a materializar — fetcheamos el JSON
+ * de usuarios para enumerar todos los ids.
  */
 export const serverRoutes: ServerRoute[] = [
+  {
+    path: 'usuarios/:id',
+    renderMode: RenderMode.Prerender,
+    getPrerenderParams: async () => {
+      const response = await fetch(environment.apis.users);
+      if (!response.ok) {
+        throw new Error('Failed to fetch users for prerender: HTTP ' + String(response.status));
+      }
+      const users = (await response.json()) as ReadonlyArray<{ id: number }>;
+      return users.map((u) => ({ id: String(u.id) }));
+    },
+  },
   {
     path: '**',
     renderMode: RenderMode.Prerender,

--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -28,6 +28,20 @@ export const serverRoutes: ServerRoute[] = [
     },
   },
   {
+    path: 'repositorios/:id',
+    renderMode: RenderMode.Prerender,
+    getPrerenderParams: async () => {
+      const response = await fetch(environment.apis.repositories);
+      if (!response.ok) {
+        throw new Error(
+          'Failed to fetch repositories for prerender: HTTP ' + String(response.status),
+        );
+      }
+      const repos = (await response.json()) as ReadonlyArray<{ id: number }>;
+      return repos.map((r) => ({ id: String(r.id) }));
+    },
+  },
+  {
     path: '**',
     renderMode: RenderMode.Prerender,
   },

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -45,6 +45,18 @@ export const routes: Routes = [
             'Repositorios destacados de la comunidad GhQuerry: lenguajes, popularidad y descripción de cada proyecto.',
         },
       },
+      {
+        path: 'repositorios/:id',
+        loadComponent: () =>
+          import('./features/repositories/repository-detail-page').then(
+            (m) => m.RepositoryDetailPage,
+          ),
+        title: 'Detalle de repositorio',
+        data: {
+          description:
+            'Perfil detallado de un repositorio GhQuerry: lenguaje, popularidad, propietario y proyectos relacionados de la comunidad.',
+        },
+      },
     ],
   },
 ];

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -26,6 +26,16 @@ export const routes: Routes = [
         },
       },
       {
+        path: 'usuarios/:id',
+        loadComponent: () =>
+          import('./features/users/user-detail-page').then((m) => m.UserDetailPage),
+        title: 'Detalle de usuario',
+        data: {
+          description:
+            'Perfil detallado de un developer GhQuerry: información de contacto, repositorios mantenidos y comunidad relacionada.',
+        },
+      },
+      {
         path: 'repositorios',
         loadComponent: () =>
           import('./features/repositories/repositories-page').then((m) => m.RepositoriesPage),

--- a/src/app/features/repositories/repositories-page.css
+++ b/src/app/features/repositories/repositories-page.css
@@ -1,44 +1,221 @@
 :host {
-  display: block;
+  /* Llena el viewport visible debajo del navbar para que el paginator
+     quede anclado al borde inferior y la grid se centre verticalmente. */
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100dvh - var(--layout-navbar-h, 4rem) - 4rem);
+
+  /* Estado inicial explícito → sin FOUC en SSR */
   opacity: 0;
   transform: translateY(16px);
   animation: pageEnter 600ms cubic-bezier(0.2, 0, 0, 1) forwards;
 }
 
-.repos-page__title,
-.repos-page__placeholder {
-  opacity: 0;
-  transform: translateY(14px);
-  animation: fadeUp 600ms cubic-bezier(0.2, 0, 0, 1) forwards;
-}
-.repos-page__title {
-  animation-delay: 100ms;
-}
-.repos-page__placeholder {
-  animation-delay: 220ms;
-}
-
 @media (prefers-reduced-motion: reduce) {
-  :host,
-  .repos-page__title,
-  .repos-page__placeholder {
+  :host {
     animation: none;
     opacity: 1;
     transform: none;
   }
 }
 
-.repos-page__title {
-  font-size: clamp(1.75rem, 1.2rem + 1.5vw, 2.5rem);
-  margin: 0 0 0.75rem;
+.repos-page {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
 }
 
-.repos-page__placeholder {
+.repos-page__toolbar {
+  margin: var(--space-4) 0 0;
+}
+
+.repos-page__main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  min-height: 0;
+  padding: clamp(2rem, 5vh, 4rem) 0 var(--space-6);
+}
+
+.repos-page__paginator {
+  margin-top: var(--space-2);
+  margin-bottom: calc(var(--space-3) * -1);
+  border-top: 1px solid var(--color-border);
+  padding-top: var(--space-3);
+}
+
+.repos-page__header {
+  margin-bottom: 0;
+}
+
+.repos-page__title {
+  font-size: clamp(1.75rem, 1.2rem + 1.5vw, 2.5rem);
+  margin: 0 0 0.5rem;
+}
+
+.repos-page__subtitle {
   margin: 0;
-  padding: 1rem 1.25rem;
+  color: var(--color-text-muted);
+  font-size: 0.9375rem;
+}
+
+.repos-page__empty {
+  margin: 0;
+  padding: var(--space-6);
   border: 1px dashed var(--color-border);
   border-radius: 0.5rem;
   background: var(--color-surface);
   color: var(--color-text-muted);
-  font-size: 0.9375rem;
+  text-align: center;
+}
+
+.repos-page__empty-action {
+  margin-top: var(--space-3);
+  padding: 0.5rem 1rem;
+  font: inherit;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text);
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease;
+}
+
+.repos-page__empty-action:hover {
+  background: var(--c-uniandes-color-neutro-30);
+  border-color: var(--c-uniandes-color-neutro-50);
+}
+
+.repos-page__empty-action:focus-visible {
+  outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
+  outline-offset: 2px;
+}
+
+/* ── Responsive grid ─────────────────────────────────────────────────── */
+.repos-grid {
+  /* CSS Grid con `auto-fill + 1fr` → todas las tracks comparten la misma
+     anchura, calculada por el grid según el viewport. Así una fila parcial
+     (2 ó 1 cards) usa los mismos tracks que la fila completa: las columnas
+     quedan alineadas verticalmente entre filas y las cards llenan el
+     ancho de la fila a cada breakpoint sin huecos a la derecha. */
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(18rem, 100%), 1fr));
+  gap: var(--space-8);
+}
+
+.repos-grid__item {
+  min-width: 0;
+  /* Animación escalonada de entrada */
+  opacity: 0;
+  transform: translateY(8px);
+  animation: fadeUp 420ms cubic-bezier(0.2, 0, 0, 1) forwards;
+}
+
+.repos-grid__item:nth-child(1) {
+  animation-delay: 40ms;
+}
+.repos-grid__item:nth-child(2) {
+  animation-delay: 80ms;
+}
+.repos-grid__item:nth-child(3) {
+  animation-delay: 120ms;
+}
+.repos-grid__item:nth-child(4) {
+  animation-delay: 160ms;
+}
+.repos-grid__item:nth-child(5) {
+  animation-delay: 200ms;
+}
+.repos-grid__item:nth-child(6) {
+  animation-delay: 240ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .repos-grid__item {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* ── Skeleton mientras carga ─────────────────────────────────────────── */
+.repo-skeleton {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-6);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 0.75rem;
+}
+
+.repo-skeleton__badge {
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 0.875rem;
+  background: var(--c-uniandes-color-neutro-30);
+  position: relative;
+  overflow: hidden;
+}
+
+.repo-skeleton__lines {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.repo-skeleton__line {
+  height: 0.75rem;
+  border-radius: 0.25rem;
+  background: var(--c-uniandes-color-neutro-30);
+  position: relative;
+  overflow: hidden;
+}
+
+.repo-skeleton__line--lg {
+  width: 70%;
+}
+.repo-skeleton__line--md {
+  width: 50%;
+}
+.repo-skeleton__line--sm {
+  width: 35%;
+}
+
+.repo-skeleton__badge::after,
+.repo-skeleton__line::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.6) 50%,
+    transparent 100%
+  );
+  transform: translateX(-100%);
+  animation: shimmer 1.4s infinite;
+}
+
+@keyframes shimmer {
+  to {
+    transform: translateX(100%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .repo-skeleton__badge::after,
+  .repo-skeleton__line::after {
+    animation: none;
+  }
 }

--- a/src/app/features/repositories/repositories-page.html
+++ b/src/app/features/repositories/repositories-page.html
@@ -1,6 +1,96 @@
-<section class="repos-page">
-  <h1 class="repos-page__title">{{ title }}</h1>
-  <p class="repos-page__placeholder">
-    Implementar componente para listar repositorios. HU pendiente de iteraciones posteriores.
-  </p>
+<section class="repos-page" aria-labelledby="repos-page-title">
+  <header class="repos-page__header">
+    <h1 id="repos-page-title" class="repos-page__title">{{ title }}</h1>
+    @if (!isLoading()) {
+      <p class="repos-page__subtitle" aria-live="polite">
+        @if (hasActiveFilters()) {
+          {{ total() }} de {{ grandTotal() }} repositorios coinciden
+        } @else {
+          {{ total() }} repositorios en la comunidad
+        }
+      </p>
+    }
+  </header>
+
+  <app-filter-toolbar
+    class="repos-page__toolbar"
+    ariaLabel="Filtros de repositorios"
+    [hasActive]="hasActiveFilters()"
+    (clear)="onReset()"
+  >
+    <app-search-input
+      ariaLabel="Buscar por nombre o descripción"
+      placeholder="Buscar por nombre o descripción…"
+      [value]="query()"
+      (valueChange)="query.set($event)"
+    />
+    <app-select-field
+      ariaLabel="Filtrar por lenguaje"
+      placeholder="Todos los lenguajes"
+      [options]="languageOptions()"
+      [value]="language()"
+      (valueChange)="language.set($event)"
+    />
+    <app-select-field
+      ariaLabel="Filtrar por propietario"
+      placeholder="Todos los propietarios"
+      [options]="ownerOptions()"
+      [value]="ownerIdStr()"
+      (valueChange)="ownerIdStr.set($event)"
+    />
+    <app-chips-field
+      ariaLabel="Filtrar por popularidad"
+      [options]="popularidadOptions"
+      [value]="popularidad()"
+      (valueChange)="popularidad.set($event)"
+    />
+  </app-filter-toolbar>
+
+  <div class="repos-page__main">
+    @if (isLoading()) {
+      <ul class="repos-grid" aria-label="Cargando repositorios" aria-busy="true">
+        @for (slot of skeletonSlots; track slot) {
+          <li class="repos-grid__item">
+            <div class="repo-skeleton" aria-hidden="true">
+              <div class="repo-skeleton__badge"></div>
+              <div class="repo-skeleton__lines">
+                <div class="repo-skeleton__line repo-skeleton__line--lg"></div>
+                <div class="repo-skeleton__line repo-skeleton__line--md"></div>
+                <div class="repo-skeleton__line repo-skeleton__line--sm"></div>
+              </div>
+            </div>
+          </li>
+        }
+      </ul>
+    } @else if (paged(); as pageEntries) {
+      @if (pageEntries.length === 0) {
+        <div class="repos-page__empty">
+          <p>No hay repositorios que coincidan con los filtros.</p>
+          @if (hasActiveFilters()) {
+            <button type="button" class="repos-page__empty-action" (click)="onReset()">
+              Limpiar filtros
+            </button>
+          }
+        </div>
+      } @else {
+        <ul class="repos-grid">
+          @for (entry of pageEntries; track entry.repo.id) {
+            <li class="repos-grid__item">
+              <app-repository-card [repository]="entry.repo" [owner]="entry.owner" />
+            </li>
+          }
+        </ul>
+      }
+    }
+  </div>
+
+  @if (!isLoading() && total() > pageSize) {
+    <app-paginator
+      class="repos-page__paginator"
+      [total]="total()"
+      [pageSize]="pageSize"
+      [page]="page()"
+      (pageChange)="onPageChange($event)"
+    />
+  }
 </section>

--- a/src/app/features/repositories/repositories-page.ts
+++ b/src/app/features/repositories/repositories-page.ts
@@ -144,7 +144,9 @@ export class RepositoriesPage {
   constructor() {
     effect(() => {
       this.filters();
-      untracked(() => { this.page.set(1); });
+      untracked(() => {
+        this.page.set(1);
+      });
     });
   }
 

--- a/src/app/features/repositories/repositories-page.ts
+++ b/src/app/features/repositories/repositories-page.ts
@@ -49,18 +49,14 @@ export class RepositoriesPage {
   protected readonly pageSize = 6;
 
   /**
-   * Query param `?owner=:id` leído reactivamente desde `ActivatedRoute`.
-   * Cuando se entra desde el badge de repositorios de un `UserCard`,
-   * pre-aplica el filtro de propietario.
+   * Query params leídos reactivamente desde `ActivatedRoute`. Pre-aplica
+   * los filtros internos cuando se entra con `?owner=:id` (desde el badge
+   * de repos de un `UserCard`) o `?language=:name` (desde el chip de
+   * lenguaje de un `RepositoryCard`).
    */
-  private readonly ownerFromUrl = toSignal(
-    this.route.queryParamMap
-      .pipe
-      // Map a string | null para comparar/asignar fácilmente.
-      // (queryParamMap.get devuelve null cuando no existe).
-      (),
-    { initialValue: this.route.snapshot.queryParamMap },
-  );
+  private readonly queryParams = toSignal(this.route.queryParamMap, {
+    initialValue: this.route.snapshot.queryParamMap,
+  });
 
   /* ── Estado de filtros ─────────────────────────────────────────────── */
   protected readonly query = signal('');
@@ -157,17 +153,23 @@ export class RepositoriesPage {
   protected readonly skeletonSlots = Array.from({ length: this.pageSize }, (_, i) => i);
 
   constructor() {
-    /* Cuando se entra desde un UserCard con `?owner=:id`, sincroniza el
-       query param al filtro interno. `untracked` para no crear un loop
-       cuando el efecto siguiente lee el filtro derivado. */
+    /* Cuando se entra desde otra página con `?owner=:id` (badge de repos
+       de un UserCard) o `?language=:name` (chip de lenguaje de un
+       RepositoryCard), sincroniza los query params a los filtros internos.
+       `untracked` evita un loop con el efecto siguiente que reacciona a
+       cambios en `filters()`. */
     effect(() => {
-      const fromUrl = this.ownerFromUrl().get('owner');
-      if (fromUrl !== null) {
-        const current = untracked(() => this.ownerIdStr());
-        if (current !== fromUrl) {
-          this.ownerIdStr.set(fromUrl);
+      const params = this.queryParams();
+      const ownerParam = params.get('owner');
+      const languageParam = params.get('language');
+      untracked(() => {
+        if (ownerParam !== null && this.ownerIdStr() !== ownerParam) {
+          this.ownerIdStr.set(ownerParam);
         }
-      }
+        if (languageParam !== null && this.language() !== languageParam) {
+          this.language.set(languageParam);
+        }
+      });
     });
 
     /* Cualquier cambio en filtros nos devuelve a la página 1. */

--- a/src/app/features/repositories/repositories-page.ts
+++ b/src/app/features/repositories/repositories-page.ts
@@ -1,11 +1,164 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  signal,
+  untracked,
+} from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { debounceTime, distinctUntilChanged } from 'rxjs';
+
+import { RepositoryCard } from '@shared/ui/repository-card/repository-card';
+import { Paginator } from '@shared/ui/paginator/paginator';
+import {
+  type ChipOption,
+  ChipsField,
+  FilterToolbar,
+  SearchInputField,
+  type SelectOption,
+  SelectField,
+} from '@shared/ui/filter-toolbar';
+import { Users } from '@features/users';
+import type { User } from '@features/users/user';
+import { Repositories } from './repositories';
+import type { Repository, RepositoryFilters } from './repository';
+
+interface RepoEntry {
+  readonly repo: Repository;
+  readonly owner: User | null;
+}
+
+const POPULARITY_THRESHOLD = 100;
 
 @Component({
   selector: 'app-repositories-page',
+  imports: [RepositoryCard, Paginator, FilterToolbar, SearchInputField, ChipsField, SelectField],
   templateUrl: './repositories-page.html',
   styleUrl: './repositories-page.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RepositoriesPage {
+  private readonly reposService = inject(Repositories);
+  private readonly usersService = inject(Users);
+
   protected readonly title = 'Repositorios';
+  protected readonly pageSize = 6;
+
+  /* ── Estado de filtros ─────────────────────────────────────────────── */
+  protected readonly query = signal('');
+  protected readonly language = signal<string | null>(null);
+  protected readonly ownerIdStr = signal<string | null>(null);
+  protected readonly popularidad = signal<boolean | null>(null);
+  protected readonly page = signal(1);
+
+  protected readonly popularidadOptions: ReadonlyArray<ChipOption<boolean>> = [
+    { value: true, label: 'Populares' },
+    { value: false, label: 'Emergentes' },
+  ];
+
+  /* ── Datos ─────────────────────────────────────────────────────────── */
+  private readonly allRepos = toSignal(this.reposService.list(), { initialValue: undefined });
+  private readonly allUsers = toSignal(this.usersService.list(), { initialValue: undefined });
+
+  private readonly userById = computed<ReadonlyMap<number, User> | null>(() => {
+    const list = this.allUsers();
+    if (!list) return null;
+    const map = new Map<number, User>();
+    for (const u of list) map.set(u.id, u);
+    return map;
+  });
+
+  /* Debounce sólo del input de texto. */
+  private readonly debouncedQuery = toSignal(
+    toObservable(this.query).pipe(debounceTime(200), distinctUntilChanged()),
+    { initialValue: '' },
+  );
+
+  protected readonly filters = computed<RepositoryFilters>(() => {
+    const f: { -readonly [K in keyof RepositoryFilters]?: RepositoryFilters[K] } = {};
+    const q = this.debouncedQuery().trim();
+    if (q.length > 0) f.query = q;
+    const lang = this.language();
+    if (lang !== null) f.language = lang;
+    const oid = this.ownerIdStr();
+    if (oid !== null) f.ownerId = Number(oid);
+    const pop = this.popularidad();
+    if (pop === true) f.minStars = POPULARITY_THRESHOLD;
+    if (pop === false) f.maxStars = POPULARITY_THRESHOLD - 1;
+    return f;
+  });
+
+  protected readonly hasActiveFilters = computed(() => Object.keys(this.filters()).length > 0);
+
+  protected readonly filtered = computed(() => {
+    const list = this.allRepos();
+    if (!list) return undefined;
+    return list.filter((r) => r.matches(this.filters()));
+  });
+
+  /* Opciones de filtro derivadas del snapshot. */
+  protected readonly languageOptions = computed<ReadonlyArray<SelectOption<string>>>(() => {
+    const list = this.allRepos();
+    if (!list) return [];
+    const seen = new Set<string>();
+    for (const r of list) seen.add(r.language);
+    return Array.from(seen)
+      .sort((a, b) => a.localeCompare(b))
+      .map((lang) => ({ value: lang, label: lang }));
+  });
+
+  protected readonly ownerOptions = computed<ReadonlyArray<SelectOption<string>>>(() => {
+    const repos = this.allRepos();
+    const users = this.allUsers();
+    if (!repos || !users) return [];
+    const ownerIds = new Set<number>();
+    for (const r of repos) ownerIds.add(r.ownerId);
+    return Array.from(ownerIds)
+      .map((id) => users.find((u) => u.id === id))
+      .filter((u): u is User => u !== undefined)
+      .sort((a, b) => a.name.localeCompare(b.name, 'es'))
+      .map((u) => ({ value: String(u.id), label: u.name }));
+  });
+
+  protected readonly total = computed(() => this.filtered()?.length ?? 0);
+  protected readonly grandTotal = computed(() => this.allRepos()?.length ?? 0);
+  protected readonly isLoading = computed(
+    () => this.allRepos() === undefined || this.allUsers() === undefined,
+  );
+
+  protected readonly paged = computed<readonly RepoEntry[] | undefined>(() => {
+    const list = this.filtered();
+    if (!list) return undefined;
+    const map = this.userById();
+    const start = (this.page() - 1) * this.pageSize;
+    return list.slice(start, start + this.pageSize).map((repo) => ({
+      repo,
+      owner: map?.get(repo.ownerId) ?? null,
+    }));
+  });
+
+  protected readonly skeletonSlots = Array.from({ length: this.pageSize }, (_, i) => i);
+
+  constructor() {
+    effect(() => {
+      this.filters();
+      untracked(() => { this.page.set(1); });
+    });
+  }
+
+  protected onPageChange(page: number): void {
+    this.page.set(page);
+    if (typeof window !== 'undefined') {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  }
+
+  protected onReset(): void {
+    this.query.set('');
+    this.language.set(null);
+    this.ownerIdStr.set(null);
+    this.popularidad.set(null);
+  }
 }

--- a/src/app/features/repositories/repositories-page.ts
+++ b/src/app/features/repositories/repositories-page.ts
@@ -8,6 +8,7 @@ import {
   untracked,
 } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute } from '@angular/router';
 import { debounceTime, distinctUntilChanged } from 'rxjs';
 
 import { RepositoryCard } from '@shared/ui/repository-card/repository-card';
@@ -42,9 +43,24 @@ const POPULARITY_THRESHOLD = 100;
 export class RepositoriesPage {
   private readonly reposService = inject(Repositories);
   private readonly usersService = inject(Users);
+  private readonly route = inject(ActivatedRoute);
 
   protected readonly title = 'Repositorios';
   protected readonly pageSize = 6;
+
+  /**
+   * Query param `?owner=:id` leído reactivamente desde `ActivatedRoute`.
+   * Cuando se entra desde el badge de repositorios de un `UserCard`,
+   * pre-aplica el filtro de propietario.
+   */
+  private readonly ownerFromUrl = toSignal(
+    this.route.queryParamMap
+      .pipe
+      // Map a string | null para comparar/asignar fácilmente.
+      // (queryParamMap.get devuelve null cuando no existe).
+      (),
+    { initialValue: this.route.snapshot.queryParamMap },
+  );
 
   /* ── Estado de filtros ─────────────────────────────────────────────── */
   protected readonly query = signal('');
@@ -110,14 +126,13 @@ export class RepositoriesPage {
   });
 
   protected readonly ownerOptions = computed<ReadonlyArray<SelectOption<string>>>(() => {
-    const repos = this.allRepos();
     const users = this.allUsers();
-    if (!repos || !users) return [];
-    const ownerIds = new Set<number>();
-    for (const r of repos) ownerIds.add(r.ownerId);
-    return Array.from(ownerIds)
-      .map((id) => users.find((u) => u.id === id))
-      .filter((u): u is User => u !== undefined)
+    if (!users) return [];
+    /* Incluimos a TODOS los usuarios — incluso los que no mantienen
+       repositorios — para que el filtro pueda seleccionarlos (entrada
+       desde el badge "Sin repositorios" del UserCard) y el SelectField
+       muestre el label correcto. */
+    return [...users]
       .sort((a, b) => a.name.localeCompare(b.name, 'es'))
       .map((u) => ({ value: String(u.id), label: u.name }));
   });
@@ -142,6 +157,20 @@ export class RepositoriesPage {
   protected readonly skeletonSlots = Array.from({ length: this.pageSize }, (_, i) => i);
 
   constructor() {
+    /* Cuando se entra desde un UserCard con `?owner=:id`, sincroniza el
+       query param al filtro interno. `untracked` para no crear un loop
+       cuando el efecto siguiente lee el filtro derivado. */
+    effect(() => {
+      const fromUrl = this.ownerFromUrl().get('owner');
+      if (fromUrl !== null) {
+        const current = untracked(() => this.ownerIdStr());
+        if (current !== fromUrl) {
+          this.ownerIdStr.set(fromUrl);
+        }
+      }
+    });
+
+    /* Cualquier cambio en filtros nos devuelve a la página 1. */
     effect(() => {
       this.filters();
       untracked(() => {

--- a/src/app/features/repositories/repository-detail-page.css
+++ b/src/app/features/repositories/repository-detail-page.css
@@ -14,14 +14,14 @@
   }
 }
 
-.user-detail {
+.repo-detail {
   display: flex;
   flex-direction: column;
   gap: var(--space-8);
 }
 
 /* ── Back link ───────────────────────────────────────────────────────── */
-.user-detail__back {
+.repo-detail__back {
   display: inline-flex;
   align-items: center;
   gap: 0.375rem;
@@ -41,34 +41,34 @@
     transform 160ms ease;
 }
 
-.user-detail__back:hover {
+.repo-detail__back:hover {
   color: var(--color-text);
   border-color: var(--c-uniandes-color-neutro-50);
   background: var(--color-surface);
   transform: translateX(-2px);
 }
 
-.user-detail__back:focus-visible {
+.repo-detail__back:focus-visible {
   outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
   outline-offset: 2px;
 }
 
-.user-detail__back svg {
+.repo-detail__back svg {
   width: 1rem;
   height: 1rem;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .user-detail__back {
+  .repo-detail__back {
     transition: none;
   }
-  .user-detail__back:hover {
+  .repo-detail__back:hover {
     transform: none;
   }
 }
 
 /* ── Hero ────────────────────────────────────────────────────────────── */
-.user-detail__hero {
+.repo-detail__hero {
   display: grid;
   grid-template-columns: auto 1fr;
   gap: clamp(1.5rem, 4vw, 2.5rem);
@@ -81,26 +81,27 @@
 }
 
 @media (max-width: 640px) {
-  .user-detail__hero {
+  .repo-detail__hero {
     grid-template-columns: 1fr;
     text-align: center;
     justify-items: center;
   }
 }
 
-.user-detail__avatar-stage {
+.repo-detail__badge-stage {
   width: clamp(7rem, 14vw, 10rem);
   height: clamp(7rem, 14vw, 10rem);
   flex-shrink: 0;
   perspective: 800px;
 }
 
-.user-detail__avatar {
+.repo-detail__badge {
+  display: grid;
+  place-items: center;
   width: 100%;
   height: 100%;
-  border-radius: 50%;
-  object-fit: cover;
-  background: var(--c-uniandes-color-neutro-30);
+  border-radius: clamp(1rem, 2vw, 1.5rem);
+  color: #fff;
   border: 4px solid var(--color-bg);
   box-shadow:
     0 0 0 1px var(--color-border),
@@ -110,45 +111,50 @@
   will-change: transform;
 }
 
-.user-detail__avatar--initials {
-  display: grid;
-  place-items: center;
-  font-size: clamp(2rem, 4.5vw, 3rem);
-  font-weight: 700;
-  color: var(--c-uniandes-color-primarytext-lightbg);
-  background: var(--c-uniandes-color-secondary-02-lightbg);
+.repo-detail__badge svg {
+  width: 50%;
+  height: 50%;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .user-detail__avatar {
+  .repo-detail__badge {
     transition: none;
     transform: none !important;
   }
 }
 
-.user-detail__identity {
+.repo-detail__identity {
   min-width: 0;
 }
 
-.user-detail__eyebrow {
+.repo-detail__eyebrow {
   margin: 0;
 }
 
-.user-detail__role,
-.user-detail__role:visited {
+.repo-detail__lang,
+.repo-detail__lang:visited {
   display: inline-flex;
   align-items: center;
-  gap: 0.4375rem;
+  gap: 0.5rem;
   font-size: 0.75rem;
   font-weight: 700;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  padding: 0.375rem 0.75rem 0.375rem 0.625rem;
+  padding: 0.375rem 0.875rem 0.375rem 0.75rem;
   border-radius: 999px;
-  border: 1px solid transparent;
+  /* Gradiente teñido por el lenguaje (`--lang-tint` lo setea el componente
+     vía `[style.--lang-tint]="languageColor()"`). 12/24% sobre `transparent`
+     mantiene legibilidad del texto en el surface del hero. */
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--lang-tint, var(--c-uniandes-color-neutro-50)) 12%, transparent) 0%,
+    color-mix(in srgb, var(--lang-tint, var(--c-uniandes-color-neutro-50)) 24%, transparent) 100%
+  );
+  color: var(--color-text);
+  border: 1px solid color-mix(in srgb, var(--lang-tint, var(--color-border)) 40%, transparent);
   white-space: nowrap;
   text-decoration: none;
-  /* Anillo arranca en 0 y se anima a un halo color del rol en hover. */
+  /* Anillo arranca en 0 y aparece con overshoot ligero en hover. */
   box-shadow: 0 0 0 0 transparent;
   transition:
     box-shadow 280ms cubic-bezier(0.34, 1.4, 0.64, 1),
@@ -157,83 +163,43 @@
     filter 200ms ease;
 }
 
-.user-detail__role::before {
-  content: '';
-  width: 0.5rem;
-  height: 0.5rem;
-  border-radius: 50%;
-  background: currentColor;
-  opacity: 0.65;
-  flex-shrink: 0;
-  transition: opacity 200ms ease;
-}
-
-.user-detail__role:hover,
-.user-detail__role:focus-visible {
-  box-shadow: 0 0 0 5px var(--user-detail-role-ring, transparent);
+.repo-detail__lang:hover,
+.repo-detail__lang:focus-visible {
+  /* Halo en el color del lenguaje. */
+  box-shadow: 0 0 0 5px color-mix(in srgb, var(--lang-tint, var(--color-border)) 35%, transparent);
   transform: translateY(-1px);
   filter: brightness(0.97);
 }
 
-.user-detail__role:hover::before,
-.user-detail__role:focus-visible::before {
-  opacity: 1;
-}
-
 @media (prefers-reduced-motion: reduce) {
-  .user-detail__role,
-  .user-detail__role::before {
+  .repo-detail__lang {
     transition: none;
   }
-  .user-detail__role:hover,
-  .user-detail__role:focus-visible {
+  .repo-detail__lang:hover,
+  .repo-detail__lang:focus-visible {
     transform: none;
     filter: none;
   }
 }
 
-.user-detail__role--admin,
-.user-detail__role--admin:visited {
-  background: linear-gradient(
-    135deg,
-    var(--c-uniandes-color-secondary-02-lightbg) 0%,
-    #ffd840 100%
-  );
-  color: var(--c-uniandes-color-primarytext-lightbg);
-  border-color: var(--c-uniandes-color-secondary-01-lightbg);
-  --user-detail-role-ring: rgba(255, 228, 30, 0.45);
+.repo-detail__lang-dot {
+  width: 0.625rem;
+  height: 0.625rem;
+  border-radius: 50%;
+  display: inline-block;
+  /* El dot a opacidad completa contrasta con el bg tintado al 12–24%. */
+  background: var(--lang-tint, currentColor);
+  flex-shrink: 0;
 }
 
-.user-detail__role--developer,
-.user-detail__role--developer:visited {
-  background: linear-gradient(
-    135deg,
-    var(--c-uniandes-color-neutro-30) 0%,
-    var(--c-uniandes-color-neutro-40) 100%
-  );
-  color: var(--c-uniandes-color-primarytext-lightbg);
-  border-color: var(--c-uniandes-color-neutro-50);
-  --user-detail-role-ring: rgba(138, 137, 132, 0.35);
-}
-
-.user-detail__role--designer,
-.user-detail__role--designer:visited {
-  background: linear-gradient(135deg, rgba(36, 66, 178, 0.08) 0%, rgba(36, 66, 178, 0.18) 100%);
-  color: var(--color-accent);
-  border-color: rgba(36, 66, 178, 0.35);
-  --user-detail-role-ring: rgba(36, 66, 178, 0.3);
-}
-
-.user-detail__name {
+.repo-detail__name {
   font-size: clamp(2rem, 5vw, 3rem);
   font-weight: 700;
   letter-spacing: -0.01em;
   line-height: 1.1;
-  margin: 0.5rem 0 0.25rem;
+  margin: 0.5rem 0 0.75rem;
   color: var(--color-text);
-  /* Franja amarilla Uniandes bajo el nombre — destaca como título focal
-     de la página de detalle. `width: fit-content` ajusta la franja al
-     ancho del texto en lugar de extenderla a todo el contenedor. */
+  /* Franja amarilla Uniandes destacando el nombre como título focal. */
   width: fit-content;
   max-width: 100%;
   background-image: linear-gradient(
@@ -246,20 +212,27 @@
 }
 
 @media (max-width: 640px) {
-  .user-detail__name {
+  .repo-detail__name {
     margin-inline: auto;
   }
 }
 
-.user-detail__username {
+.repo-detail__description {
   margin: 0;
   font-size: clamp(0.9375rem, 1.5vw, 1.0625rem);
+  line-height: 1.55;
   color: var(--color-text-muted);
-  font-feature-settings: 'tnum' 1;
+  max-width: 60ch;
+}
+
+@media (max-width: 640px) {
+  .repo-detail__description {
+    margin-inline: auto;
+  }
 }
 
 /* ── Meta inline ─────────────────────────────────────────────────────── */
-.user-detail__meta {
+.repo-detail__meta {
   list-style: none;
   padding: 0;
   margin: var(--space-4) 0 0;
@@ -268,118 +241,143 @@
   gap: var(--space-2) var(--space-4);
   font-size: 0.9375rem;
   color: var(--color-text-muted);
+  align-items: center;
 }
 
-.user-detail__meta-item {
+.repo-detail__meta-item {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: 0.5rem;
   min-width: 0;
 }
 
-.user-detail__meta-item svg {
+.repo-detail__meta-item svg {
   width: 1rem;
   height: 1rem;
   color: var(--c-uniandes-color-neutro-70);
   flex-shrink: 0;
 }
 
-.user-detail__meta-item a {
+.repo-detail__meta-item--static {
+  color: var(--color-text-muted);
+}
+
+.repo-detail__owner-link,
+.repo-detail__owner-link:visited {
   display: inline-flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: 0.5rem;
   color: inherit;
   text-decoration: none;
   border-radius: 0.25rem;
   transition: color 160ms ease;
 }
 
-.user-detail__meta-item a:hover {
+.repo-detail__owner-link:hover,
+.repo-detail__owner-link:focus-visible {
   color: var(--color-text);
 }
 
-.user-detail__meta-item a:hover span {
+.repo-detail__owner-link:hover .repo-detail__owner-name {
   text-decoration: underline;
 }
 
-.user-detail__meta-item a:focus-visible {
+.repo-detail__owner-link:focus-visible {
   outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
   outline-offset: 2px;
 }
 
-.user-detail__meta-item--static {
-  color: var(--color-text-muted);
+.repo-detail__owner-avatar {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+  background: var(--c-uniandes-color-neutro-30);
+  border: 2px solid var(--color-bg);
+  box-shadow: 0 0 0 1px var(--color-border);
+}
+
+.repo-detail__owner-avatar--initials {
+  display: grid;
+  place-items: center;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: var(--color-text);
+  background: var(--c-uniandes-color-secondary-02-lightbg);
+}
+
+.repo-detail__owner-name {
+  font-weight: 500;
+}
+
+.repo-detail__owner-unknown {
+  font-style: italic;
+  color: var(--color-text-disabled);
 }
 
 @media (max-width: 640px) {
-  .user-detail__meta {
+  .repo-detail__meta {
     justify-content: center;
   }
 }
 
-/* ── Section blocks (repos + others) ─────────────────────────────────── */
-.user-detail__section {
+/* ── Stars badge (igual que RepositoryCard, con 4 tiers) ─────────────── */
+.repo-detail__stars {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  padding: 0.3125rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+}
+
+.repo-detail__stars--low {
+  background: var(--c-uniandes-color-neutro-30);
+  color: var(--color-text);
+  border-color: var(--color-border);
+}
+.repo-detail__stars--mid {
+  background: rgba(36, 66, 178, 0.08);
+  color: var(--color-accent);
+  border-color: rgba(36, 66, 178, 0.25);
+}
+.repo-detail__stars--high {
+  background: rgba(11, 115, 16, 0.1);
+  color: var(--c-uniandes-color-success-lightbg);
+  border-color: rgba(11, 115, 16, 0.3);
+}
+.repo-detail__stars--top {
+  background: var(--c-uniandes-color-secondary-02-lightbg);
+  color: var(--c-uniandes-color-primarytext-lightbg);
+  border-color: var(--c-uniandes-color-secondary-01-lightbg);
+}
+.repo-detail__stars--top svg {
+  color: var(--c-uniandes-color-alert-lightbg);
+}
+
+/* ── Section blocks (otros repos del owner / similares) ──────────────── */
+.repo-detail__section {
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
 }
 
-.user-detail__section-title {
+.repo-detail__section-title {
   font-size: clamp(1.25rem, 2vw, 1.5rem);
   font-weight: 600;
   margin: 0;
   color: var(--color-text);
 }
 
-.user-detail__empty {
-  margin: 0;
-  padding: var(--space-6);
-  border: 1px dashed var(--color-border);
-  border-radius: 0.5rem;
-  background: var(--color-surface);
-  color: var(--color-text-muted);
-  text-align: center;
-  font-size: 0.9375rem;
-}
-
-/* ── Repos grid (mismo CSS Grid uniforme que las otras páginas) ──────── */
-.user-detail__repos-grid {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(min(18rem, 100%), 1fr));
-  gap: var(--space-6);
-}
-
-.user-detail__repos-item {
-  min-width: 0;
-  opacity: 0;
-  transform: translateY(8px);
-  animation: fadeUp 420ms cubic-bezier(0.2, 0, 0, 1) forwards;
-}
-
-.user-detail__repos-item:nth-child(1) {
-  animation-delay: 60ms;
-}
-.user-detail__repos-item:nth-child(2) {
-  animation-delay: 120ms;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .user-detail__repos-item {
-    animation: none;
-    opacity: 1;
-    transform: none;
-  }
-}
-
-/* ── Rail horizontal de "otros usuarios" ─────────────────────────────── */
-.user-detail__rail-wrapper {
+/* ── Rail horizontal ─────────────────────────────────────────────────── */
+.repo-detail__rail-wrapper {
   position: relative;
 }
 
-.user-detail__rail {
+.repo-detail__rail {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -388,18 +386,37 @@
   overflow-x: auto;
   scroll-behavior: smooth;
   scroll-snap-type: x proximity;
-  /* Scrollbar nativa oculta — la navegación del rail se hace con las
-     flechas. Mantenemos overflow auto para conservar swipe táctil y
-     scroll-wheel horizontal. */
   scrollbar-width: none;
 }
 
-.user-detail__rail::-webkit-scrollbar {
+.repo-detail__rail::-webkit-scrollbar {
   display: none;
 }
 
-/* ── Flechas de control ──────────────────────────────────────────────── */
-.user-detail__rail-arrow {
+@media (prefers-reduced-motion: reduce) {
+  .repo-detail__rail {
+    scroll-behavior: auto;
+  }
+}
+
+.repo-detail__rail-item {
+  scroll-snap-align: start;
+  flex-shrink: 0;
+}
+
+/* En viewports estrechos, una mini-card aislada llena el ancho del rail
+   en lugar de quedarse a 14rem con espacio vacío a la derecha. Si hay
+   varias mini-cards, mantienen su ancho fijo para preservar el patrón
+   de carrusel deslizable. */
+@media (max-width: 640px) {
+  .repo-detail__rail-item:only-child,
+  .repo-detail__rail-item:only-child .other-repo {
+    width: 100%;
+  }
+}
+
+/* ── Flechas de control del rail ─────────────────────────────────────── */
+.repo-detail__rail-arrow {
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
@@ -423,103 +440,99 @@
     transform 160ms ease;
 }
 
-.user-detail__rail-arrow:hover:not(:disabled) {
+.repo-detail__rail-arrow:hover:not(:disabled) {
   background: var(--c-uniandes-color-secondary-01-lightbg);
   border-color: var(--c-uniandes-color-secondary-01-lightbg);
   color: var(--c-uniandes-color-primarytext-lightbg);
   transform: translateY(-50%) scale(1.06);
 }
 
-.user-detail__rail-arrow:focus-visible {
+.repo-detail__rail-arrow:focus-visible {
   outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
   outline-offset: 2px;
 }
 
-.user-detail__rail-arrow:disabled {
+.repo-detail__rail-arrow:disabled {
   opacity: 0;
   pointer-events: none;
 }
 
-.user-detail__rail-arrow svg {
+.repo-detail__rail-arrow svg {
   width: 1.125rem;
   height: 1.125rem;
 }
 
-.user-detail__rail-arrow--prev {
+.repo-detail__rail-arrow--prev {
   left: -0.5rem;
 }
 
-.user-detail__rail-arrow--next {
+.repo-detail__rail-arrow--next {
   right: -0.5rem;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .user-detail__rail {
-    scroll-behavior: auto;
-  }
-  .user-detail__rail-arrow {
+  .repo-detail__rail-arrow {
     transition: none;
   }
-  .user-detail__rail-arrow:hover:not(:disabled) {
+  .repo-detail__rail-arrow:hover:not(:disabled) {
     transform: translateY(-50%);
   }
 }
 
-.user-detail__rail-item {
-  scroll-snap-align: start;
-  flex-shrink: 0;
-}
-
-.other-user {
+/* ── Mini repo card del rail ─────────────────────────────────────────── */
+.other-repo {
   display: grid;
-  grid-template-rows: auto auto auto;
-  gap: 0.375rem;
-  width: 11rem;
+  grid-template-rows: auto auto auto auto;
+  gap: var(--space-2);
+  width: 14rem;
   padding: var(--space-4);
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: 0.75rem;
   text-decoration: none;
   color: inherit;
-  text-align: center;
-  justify-items: center;
+  justify-items: start;
   transition:
     transform 220ms cubic-bezier(0.2, 0, 0, 1),
     border-color 220ms cubic-bezier(0.2, 0, 0, 1),
     box-shadow 220ms cubic-bezier(0.2, 0, 0, 1);
 }
 
-.other-user:hover {
+.other-repo:hover {
   transform: translateY(-2px);
   border-color: var(--c-uniandes-color-neutro-50);
   box-shadow: 0 6px 18px rgba(25, 25, 22, 0.08);
 }
 
-.other-user:focus-visible {
+.other-repo:focus-visible {
   outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
   outline-offset: 2px;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .other-user {
+  .other-repo {
     transition: none;
   }
-  .other-user:hover {
+  .other-repo:hover {
     transform: none;
   }
 }
 
-.other-user__avatar {
-  width: 3.5rem;
-  height: 3.5rem;
-  border-radius: 50%;
-  object-fit: cover;
-  background: var(--c-uniandes-color-neutro-30);
-  border: 2px solid var(--color-bg);
-  box-shadow: 0 0 0 1px var(--color-border);
+.other-repo__badge {
+  display: grid;
+  place-items: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 0.5rem;
+  color: #fff;
 }
 
-.other-user__name {
+.other-repo__badge svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.other-repo__name {
   font-size: 0.9375rem;
   font-weight: 600;
   color: var(--color-text);
@@ -529,56 +542,108 @@
   max-width: 100%;
 }
 
-.other-user__role {
-  font-size: 0.6875rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  padding: 0.125rem 0.5rem;
+.other-repo__description {
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+  /* 2 líneas como máximo */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  overflow: hidden;
+  max-width: 100%;
+}
+
+/* Owner del rail "Repositorios similares en {language}" — avatar mini +
+   nombre, alineado a la izquierda y truncado si es largo. */
+.other-repo__owner {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  min-width: 0;
+  max-width: 100%;
+}
+
+.other-repo__owner-avatar {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+  background: var(--c-uniandes-color-neutro-30);
+  border: 1px solid var(--color-border);
+}
+
+.other-repo__owner-name {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.other-repo__stars {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 0.1875rem 0.5rem;
   border-radius: 999px;
   border: 1px solid transparent;
-  white-space: nowrap;
 }
 
-.other-user__role--admin {
-  background: var(--c-uniandes-color-secondary-02-lightbg);
-  color: var(--c-uniandes-color-primarytext-lightbg);
-  border-color: var(--c-uniandes-color-secondary-01-lightbg);
+.other-repo__stars svg {
+  width: 0.75rem;
+  height: 0.75rem;
 }
 
-.other-user__role--developer {
+.other-repo__stars--low {
   background: var(--c-uniandes-color-neutro-30);
-  color: var(--c-uniandes-color-primarytext-lightbg);
+  color: var(--color-text);
   border-color: var(--color-border);
 }
-
-.other-user__role--designer {
+.other-repo__stars--mid {
   background: rgba(36, 66, 178, 0.08);
   color: var(--color-accent);
   border-color: rgba(36, 66, 178, 0.25);
 }
+.other-repo__stars--high {
+  background: rgba(11, 115, 16, 0.1);
+  color: var(--c-uniandes-color-success-lightbg);
+  border-color: rgba(11, 115, 16, 0.3);
+}
+.other-repo__stars--top {
+  background: var(--c-uniandes-color-secondary-02-lightbg);
+  color: var(--c-uniandes-color-primarytext-lightbg);
+  border-color: var(--c-uniandes-color-secondary-01-lightbg);
+}
+.other-repo__stars--top svg {
+  color: var(--c-uniandes-color-alert-lightbg);
+}
 
 /* ── Skeleton del hero ───────────────────────────────────────────────── */
-.user-detail__hero--skeleton {
+.repo-detail__hero--skeleton {
   pointer-events: none;
 }
 
-.user-detail__avatar-skeleton {
+.repo-detail__badge-skeleton {
   width: clamp(7rem, 14vw, 10rem);
   height: clamp(7rem, 14vw, 10rem);
-  border-radius: 50%;
+  border-radius: clamp(1rem, 2vw, 1.5rem);
   background: var(--c-uniandes-color-neutro-30);
   position: relative;
   overflow: hidden;
 }
 
-.user-detail__skeleton-lines {
+.repo-detail__skeleton-lines {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
 }
 
-.user-detail__skeleton-line {
+.repo-detail__skeleton-line {
   height: 1rem;
   border-radius: 0.25rem;
   background: var(--c-uniandes-color-neutro-30);
@@ -586,20 +651,20 @@
   overflow: hidden;
 }
 
-.user-detail__skeleton-line--lg {
+.repo-detail__skeleton-line--lg {
   width: 60%;
   height: 2rem;
 }
-.user-detail__skeleton-line--md {
-  width: 30%;
+.repo-detail__skeleton-line--md {
+  width: 80%;
 }
-.user-detail__skeleton-line--sm {
+.repo-detail__skeleton-line--sm {
   width: 45%;
   height: 0.875rem;
 }
 
-.user-detail__avatar-skeleton::after,
-.user-detail__skeleton-line::after {
+.repo-detail__badge-skeleton::after,
+.repo-detail__skeleton-line::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -614,14 +679,14 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .user-detail__avatar-skeleton::after,
-  .user-detail__skeleton-line::after {
+  .repo-detail__badge-skeleton::after,
+  .repo-detail__skeleton-line::after {
     animation: none;
   }
 }
 
 /* ── Not found ───────────────────────────────────────────────────────── */
-.user-detail__not-found {
+.repo-detail__not-found {
   text-align: center;
   padding: var(--space-8) var(--space-4);
   background: var(--color-surface);
@@ -629,17 +694,17 @@
   border-radius: 0.75rem;
 }
 
-.user-detail__not-found h1 {
+.repo-detail__not-found h1 {
   font-size: clamp(1.5rem, 3vw, 2rem);
   margin: 0 0 var(--space-2);
 }
 
-.user-detail__not-found p {
+.repo-detail__not-found p {
   margin: 0 0 var(--space-4);
   color: var(--color-text-muted);
 }
 
-.user-detail__cta {
+.repo-detail__cta {
   display: inline-block;
   padding: 0.625rem 1.25rem;
   font-weight: 500;
@@ -654,13 +719,13 @@
     transform 160ms ease;
 }
 
-.user-detail__cta:hover {
+.repo-detail__cta:hover {
   background: var(--c-uniandes-color-secondary-01-lightbg);
   color: var(--c-uniandes-color-primarytext-lightbg);
   transform: translateY(-1px);
 }
 
-.user-detail__cta:focus-visible {
+.repo-detail__cta:focus-visible {
   outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
   outline-offset: 2px;
 }

--- a/src/app/features/repositories/repository-detail-page.html
+++ b/src/app/features/repositories/repository-detail-page.html
@@ -1,0 +1,313 @@
+<section class="repo-detail">
+  <a routerLink="/repositorios" class="repo-detail__back">
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        d="M15 18l-6-6 6-6"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+    Volver a repositorios
+  </a>
+
+  @if (isLoading()) {
+    <div class="repo-detail__hero repo-detail__hero--skeleton" aria-hidden="true">
+      <div class="repo-detail__badge-skeleton"></div>
+      <div class="repo-detail__skeleton-lines">
+        <div class="repo-detail__skeleton-line repo-detail__skeleton-line--lg"></div>
+        <div class="repo-detail__skeleton-line repo-detail__skeleton-line--md"></div>
+        <div class="repo-detail__skeleton-line repo-detail__skeleton-line--sm"></div>
+      </div>
+    </div>
+  } @else if (notFound()) {
+    <div class="repo-detail__not-found">
+      <h1>Repositorio no encontrado</h1>
+      <p>El repositorio solicitado no existe o ha sido eliminado.</p>
+      <a routerLink="/repositorios" class="repo-detail__cta">Ver todos los repositorios</a>
+    </div>
+  } @else if (repository(); as r) {
+    <header class="repo-detail__hero">
+      <div
+        class="repo-detail__badge-stage"
+        (mousemove)="onBadgeMove($event)"
+        (mouseleave)="onBadgeLeave()"
+      >
+        <div
+          class="repo-detail__badge"
+          [style.background-color]="languageColor()"
+          [style.transform]="
+            'rotateX(' + tilt().x + 'deg) rotateY(' + tilt().y + 'deg) scale(' + tilt().scale + ')'
+          "
+          aria-hidden="true"
+        >
+          <svg viewBox="0 0 24 24" focusable="false">
+            <path
+              d="M9.4 16.6 4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0L19.2 12l-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+      </div>
+
+      <div class="repo-detail__identity">
+        <p class="repo-detail__eyebrow">
+          <a
+            class="repo-detail__lang"
+            routerLink="/repositorios"
+            [queryParams]="{ language: r.language }"
+            [style.--lang-tint]="languageColor()"
+            [attr.aria-label]="'Filtrar repositorios por ' + r.language"
+          >
+            <span class="repo-detail__lang-dot" aria-hidden="true"></span>
+            {{ r.language }}
+          </a>
+        </p>
+        <h1 class="repo-detail__name">{{ r.name }}</h1>
+        <p class="repo-detail__description">{{ r.description }}</p>
+
+        <ul class="repo-detail__meta">
+          <li class="repo-detail__meta-item">
+            @if (owner(); as o) {
+              <a
+                [routerLink]="['/usuarios', o.id]"
+                class="repo-detail__owner-link"
+                [attr.aria-label]="'Ver perfil de ' + o.name"
+              >
+                @if (avatarFailed()) {
+                  <span
+                    class="repo-detail__owner-avatar repo-detail__owner-avatar--initials"
+                    aria-hidden="true"
+                  >
+                    {{ ownerInitials() }}
+                  </span>
+                } @else {
+                  <img
+                    class="repo-detail__owner-avatar"
+                    [src]="o.avatarUrl"
+                    [alt]=""
+                    width="32"
+                    height="32"
+                    decoding="async"
+                    (error)="onAvatarError()"
+                  />
+                }
+                <span class="repo-detail__owner-name">{{ o.name }}</span>
+              </a>
+            } @else {
+              <span class="repo-detail__owner-unknown">Propietario desconocido</span>
+            }
+          </li>
+          <li class="repo-detail__meta-item repo-detail__meta-item--static">
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path
+                d="M7 2a1 1 0 0 1 1 1v1h8V3a1 1 0 1 1 2 0v1h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2V3a1 1 0 0 1 1-1zm13 8H4v10h16V10zM4 8h16V6h-2v1a1 1 0 1 1-2 0V6H8v1a1 1 0 1 1-2 0V6H4v2z"
+                fill="currentColor"
+              />
+            </svg>
+            <time [attr.datetime]="r.createdAt">{{ createdAtLabel() }}</time>
+          </li>
+          <li class="repo-detail__meta-item">
+            <span class="repo-detail__stars repo-detail__stars--{{ starsTier() }}">
+              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path
+                  d="M12 2.5l2.95 5.97 6.59.96-4.77 4.65 1.13 6.56L12 17.55l-5.9 3.09 1.13-6.56-4.77-4.65 6.59-.96L12 2.5z"
+                  fill="currentColor"
+                />
+              </svg>
+              {{ starsLabel() }}
+            </span>
+          </li>
+        </ul>
+      </div>
+    </header>
+
+    @if (otherReposBySameOwner().length > 0 && owner(); as o) {
+      <section class="repo-detail__section" aria-labelledby="repo-detail-owner-title">
+        <h2 id="repo-detail-owner-title" class="repo-detail__section-title">
+          Otros repositorios de {{ o.name }}
+        </h2>
+        <div class="repo-detail__rail-wrapper">
+          <button
+            type="button"
+            class="repo-detail__rail-arrow repo-detail__rail-arrow--prev"
+            (click)="scrollOwnerPrev()"
+            [disabled]="!canScrollOwnerPrev()"
+            aria-label="Ver repositorios anteriores"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path
+                d="M15 18l-6-6 6-6"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2.25"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
+          <ul
+            #ownerRailEl
+            class="repo-detail__rail"
+            aria-label="Otros repositorios del propietario"
+            (scroll)="onOwnerRailScroll()"
+          >
+            @for (repo of otherReposBySameOwner(); track repo.id) {
+              <li class="repo-detail__rail-item">
+                <a
+                  [routerLink]="['/repositorios', repo.id]"
+                  class="other-repo"
+                  [attr.aria-label]="'Ver detalle de ' + repo.name"
+                >
+                  <div
+                    class="other-repo__badge"
+                    [style.background-color]="colorOf(repo)"
+                    aria-hidden="true"
+                  >
+                    <svg viewBox="0 0 24 24" focusable="false">
+                      <path
+                        d="M9.4 16.6 4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0L19.2 12l-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </div>
+                  <span class="other-repo__name">{{ repo.name }}</span>
+                  <span class="other-repo__description">{{ repo.description }}</span>
+                  <span class="other-repo__stars other-repo__stars--{{ tierOf(repo) }}">
+                    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                      <path
+                        d="M12 2.5l2.95 5.97 6.59.96-4.77 4.65 1.13 6.56L12 17.55l-5.9 3.09 1.13-6.56-4.77-4.65 6.59-.96L12 2.5z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                    {{ repo.stars }}
+                  </span>
+                </a>
+              </li>
+            }
+          </ul>
+          <button
+            type="button"
+            class="repo-detail__rail-arrow repo-detail__rail-arrow--next"
+            (click)="scrollOwnerNext()"
+            [disabled]="!canScrollOwnerNext()"
+            aria-label="Ver más repositorios"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path
+                d="M9 6l6 6-6 6"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2.25"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
+        </div>
+      </section>
+    }
+
+    @if (similarByLanguage().length > 0) {
+      <section class="repo-detail__section" aria-labelledby="repo-detail-lang-title">
+        <h2 id="repo-detail-lang-title" class="repo-detail__section-title">
+          Repositorios similares en {{ r.language }}
+        </h2>
+        <div class="repo-detail__rail-wrapper">
+          <button
+            type="button"
+            class="repo-detail__rail-arrow repo-detail__rail-arrow--prev"
+            (click)="scrollLangPrev()"
+            [disabled]="!canScrollLangPrev()"
+            aria-label="Ver repositorios anteriores"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path
+                d="M15 18l-6-6 6-6"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2.25"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
+          <ul
+            #langRailEl
+            class="repo-detail__rail"
+            aria-label="Repositorios similares en el mismo lenguaje"
+            (scroll)="onLangRailScroll()"
+          >
+            @for (repo of similarByLanguage(); track repo.id) {
+              <li class="repo-detail__rail-item">
+                <a
+                  [routerLink]="['/repositorios', repo.id]"
+                  class="other-repo"
+                  [attr.aria-label]="'Ver detalle de ' + repo.name"
+                >
+                  <div
+                    class="other-repo__badge"
+                    [style.background-color]="colorOf(repo)"
+                    aria-hidden="true"
+                  >
+                    <svg viewBox="0 0 24 24" focusable="false">
+                      <path
+                        d="M9.4 16.6 4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0L19.2 12l-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </div>
+                  <span class="other-repo__name">{{ repo.name }}</span>
+                  <span class="other-repo__description">{{ repo.description }}</span>
+                  @if (ownerOf(repo); as o) {
+                    <span class="other-repo__owner">
+                      <img
+                        class="other-repo__owner-avatar"
+                        [src]="o.avatarUrl"
+                        [alt]=""
+                        width="16"
+                        height="16"
+                        loading="lazy"
+                        decoding="async"
+                      />
+                      <span class="other-repo__owner-name">{{ o.name }}</span>
+                    </span>
+                  }
+                  <span class="other-repo__stars other-repo__stars--{{ tierOf(repo) }}">
+                    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                      <path
+                        d="M12 2.5l2.95 5.97 6.59.96-4.77 4.65 1.13 6.56L12 17.55l-5.9 3.09 1.13-6.56-4.77-4.65 6.59-.96L12 2.5z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                    {{ repo.stars }}
+                  </span>
+                </a>
+              </li>
+            }
+          </ul>
+          <button
+            type="button"
+            class="repo-detail__rail-arrow repo-detail__rail-arrow--next"
+            (click)="scrollLangNext()"
+            [disabled]="!canScrollLangNext()"
+            aria-label="Ver más repositorios"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path
+                d="M9 6l6 6-6 6"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2.25"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
+        </div>
+      </section>
+    }
+  }
+</section>

--- a/src/app/features/repositories/repository-detail-page.ts
+++ b/src/app/features/repositories/repository-detail-page.ts
@@ -1,0 +1,257 @@
+import {
+  afterNextRender,
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  type ElementRef,
+  inject,
+  input,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { RouterLink } from '@angular/router';
+
+import { Users } from '@features/users';
+import type { User } from '@features/users/user';
+import { Repositories } from './repositories';
+import type { Repository } from './repository';
+
+/**
+ * Paleta canónica de colores de lenguaje (alineada con `RepositoryCard`).
+ */
+const LANGUAGE_COLOR: Readonly<Record<string, string>> = {
+  TypeScript: '#3178c6',
+  JavaScript: '#f1e05a',
+  Python: '#3572a5',
+  Java: '#b07219',
+  Go: '#00add8',
+  Rust: '#dea584',
+  'C#': '#178600',
+  'C++': '#f34b7d',
+  Ruby: '#701516',
+  Swift: '#f05138',
+  Kotlin: '#a97bff',
+  HTML: '#e34c26',
+  CSS: '#563d7c',
+  Shell: '#89e051',
+  YAML: '#cb171e',
+};
+
+const FALLBACK_LANGUAGE_COLOR = '#73726d';
+
+const DATE_FORMATTER = new Intl.DateTimeFormat('es-CO', {
+  day: 'numeric',
+  month: 'long',
+  year: 'numeric',
+});
+
+interface BadgeTilt {
+  readonly x: number;
+  readonly y: number;
+  readonly scale: number;
+}
+
+const BADGE_REST: BadgeTilt = { x: 0, y: 0, scale: 1 };
+const BADGE_MAX_TILT_DEG = 14;
+const BADGE_MAX_SCALE = 1.18;
+const BADGE_MIN_SCALE = 1.06;
+
+type StarsTier = 'low' | 'mid' | 'high' | 'top';
+
+function tierForStars(stars: number): StarsTier {
+  if (stars >= 120) return 'top';
+  if (stars >= 80) return 'high';
+  if (stars >= 40) return 'mid';
+  return 'low';
+}
+
+@Component({
+  selector: 'app-repository-detail-page',
+  imports: [RouterLink],
+  templateUrl: './repository-detail-page.html',
+  styleUrl: './repository-detail-page.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RepositoryDetailPage {
+  /** Bound from the route param `:id` thanks to `withComponentInputBinding()`. */
+  readonly id = input.required<string>();
+
+  private readonly reposService = inject(Repositories);
+  private readonly usersService = inject(Users);
+
+  protected readonly avatarFailed = signal(false);
+  protected readonly tilt = signal<BadgeTilt>(BADGE_REST);
+
+  private readonly allRepos = toSignal(this.reposService.list(), { initialValue: undefined });
+  private readonly allUsers = toSignal(this.usersService.list(), { initialValue: undefined });
+
+  protected readonly isLoading = computed(
+    () => this.allRepos() === undefined || this.allUsers() === undefined,
+  );
+
+  protected readonly repository = computed<Repository | undefined>(() => {
+    const list = this.allRepos();
+    if (!list) return undefined;
+    const numeric = Number(this.id());
+    return list.find((r) => r.id === numeric);
+  });
+
+  protected readonly notFound = computed(
+    () => this.allRepos() !== undefined && this.repository() === undefined,
+  );
+
+  protected readonly owner = computed<User | null>(() => {
+    const r = this.repository();
+    const list = this.allUsers();
+    if (!r || !list) return null;
+    return list.find((u) => u.id === r.ownerId) ?? null;
+  });
+
+  protected readonly otherReposBySameOwner = computed<readonly Repository[]>(() => {
+    const list = this.allRepos();
+    const r = this.repository();
+    if (!list || !r) return [];
+    return list.filter((other) => other.id !== r.id && other.ownerId === r.ownerId);
+  });
+
+  protected readonly similarByLanguage = computed<readonly Repository[]>(() => {
+    const list = this.allRepos();
+    const r = this.repository();
+    if (!list || !r) return [];
+    return list.filter((other) => other.id !== r.id && other.language === r.language);
+  });
+
+  protected readonly languageColor = computed(() => {
+    const r = this.repository();
+    if (!r) return FALLBACK_LANGUAGE_COLOR;
+    return LANGUAGE_COLOR[r.language] ?? FALLBACK_LANGUAGE_COLOR;
+  });
+
+  protected readonly createdAtLabel = computed(() => {
+    const r = this.repository();
+    return r ? DATE_FORMATTER.format(r.createdAtDate) : '';
+  });
+
+  protected readonly starsLabel = computed(() => {
+    const r = this.repository();
+    if (!r) return '';
+    const n = r.stars;
+    if (n === 1) return '1 estrellita';
+    return `${String(n)} estrellitas`;
+  });
+
+  protected readonly starsTier = computed<StarsTier>(() => {
+    const r = this.repository();
+    if (!r) return 'low';
+    return tierForStars(r.stars);
+  });
+
+  protected readonly ownerInitials = computed(() => {
+    const o = this.owner();
+    if (!o) return '?';
+    const parts = o.name.trim().split(/\s+/).filter(Boolean);
+    const first = parts[0]?.[0] ?? '';
+    const last = parts.length > 1 ? (parts[parts.length - 1]?.[0] ?? '') : '';
+    return (first + last).toUpperCase() || '?';
+  });
+
+  /* ── Rails: control programático con flechas ───────────────────────── */
+  private readonly ownerRailEl = viewChild<ElementRef<HTMLElement>>('ownerRailEl');
+  private readonly langRailEl = viewChild<ElementRef<HTMLElement>>('langRailEl');
+
+  protected readonly canScrollOwnerPrev = signal(false);
+  protected readonly canScrollOwnerNext = signal(false);
+  protected readonly canScrollLangPrev = signal(false);
+  protected readonly canScrollLangNext = signal(false);
+
+  constructor() {
+    afterNextRender(() => {
+      this.recomputeRailState(this.ownerRailEl()?.nativeElement, 'owner');
+      this.recomputeRailState(this.langRailEl()?.nativeElement, 'lang');
+    });
+  }
+
+  /* Helpers para los mini-cards de los rails. */
+  protected colorOf(repo: Repository): string {
+    return LANGUAGE_COLOR[repo.language] ?? FALLBACK_LANGUAGE_COLOR;
+  }
+
+  protected tierOf(repo: Repository): StarsTier {
+    return tierForStars(repo.stars);
+  }
+
+  /** Resuelve el `User` propietario de un repo del rail (puede ser null
+   *  si el dataset de usuarios aún no cargó o no contiene ese ownerId). */
+  protected ownerOf(repo: Repository): User | null {
+    return this.allUsers()?.find((u) => u.id === repo.ownerId) ?? null;
+  }
+
+  protected onAvatarError(): void {
+    this.avatarFailed.set(true);
+  }
+
+  protected onBadgeMove(event: MouseEvent): void {
+    const stage = event.currentTarget as HTMLElement;
+    const rect = stage.getBoundingClientRect();
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
+    const nx = (event.clientX - cx) / (rect.width / 2);
+    const ny = (event.clientY - cy) / (rect.height / 2);
+    const dist = Math.min(1, Math.hypot(nx, ny));
+    const scale = BADGE_MAX_SCALE - (BADGE_MAX_SCALE - BADGE_MIN_SCALE) * dist;
+    this.tilt.set({
+      x: -ny * BADGE_MAX_TILT_DEG,
+      y: nx * BADGE_MAX_TILT_DEG,
+      scale,
+    });
+  }
+
+  protected onBadgeLeave(): void {
+    this.tilt.set(BADGE_REST);
+  }
+
+  protected onOwnerRailScroll(): void {
+    this.recomputeRailState(this.ownerRailEl()?.nativeElement, 'owner');
+  }
+
+  protected onLangRailScroll(): void {
+    this.recomputeRailState(this.langRailEl()?.nativeElement, 'lang');
+  }
+
+  protected scrollOwnerPrev(): void {
+    this.scrollRail(this.ownerRailEl()?.nativeElement, -1);
+  }
+
+  protected scrollOwnerNext(): void {
+    this.scrollRail(this.ownerRailEl()?.nativeElement, 1);
+  }
+
+  protected scrollLangPrev(): void {
+    this.scrollRail(this.langRailEl()?.nativeElement, -1);
+  }
+
+  protected scrollLangNext(): void {
+    this.scrollRail(this.langRailEl()?.nativeElement, 1);
+  }
+
+  private scrollRail(el: HTMLElement | undefined, direction: -1 | 1): void {
+    if (!el) return;
+    const delta = el.clientWidth * 0.8 * direction;
+    el.scrollBy({ left: delta, behavior: 'smooth' });
+  }
+
+  private recomputeRailState(el: HTMLElement | undefined, rail: 'owner' | 'lang'): void {
+    if (!el) return;
+    const max = el.scrollWidth - el.clientWidth;
+    const canPrev = el.scrollLeft > 0;
+    const canNext = max > 0 && el.scrollLeft < max - 1;
+    if (rail === 'owner') {
+      this.canScrollOwnerPrev.set(canPrev);
+      this.canScrollOwnerNext.set(canNext);
+    } else {
+      this.canScrollLangPrev.set(canPrev);
+      this.canScrollLangNext.set(canNext);
+    }
+  }
+}

--- a/src/app/features/users/user-detail-page.css
+++ b/src/app/features/users/user-detail-page.css
@@ -1,0 +1,606 @@
+:host {
+  display: block;
+  /* Estado inicial explícito → sin FOUC en SSR */
+  opacity: 0;
+  transform: translateY(16px);
+  animation: pageEnter 600ms cubic-bezier(0.2, 0, 0, 1) forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :host {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.user-detail {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+}
+
+/* ── Back link ───────────────────────────────────────────────────────── */
+.user-detail__back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  width: fit-content;
+  padding: 0.375rem 0.75rem 0.375rem 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  text-decoration: none;
+  transition:
+    color 160ms ease,
+    border-color 160ms ease,
+    background-color 160ms ease,
+    transform 160ms ease;
+}
+
+.user-detail__back:hover {
+  color: var(--color-text);
+  border-color: var(--c-uniandes-color-neutro-50);
+  background: var(--color-surface);
+  transform: translateX(-2px);
+}
+
+.user-detail__back:focus-visible {
+  outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
+  outline-offset: 2px;
+}
+
+.user-detail__back svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .user-detail__back {
+    transition: none;
+  }
+  .user-detail__back:hover {
+    transform: none;
+  }
+}
+
+/* ── Hero ────────────────────────────────────────────────────────────── */
+.user-detail__hero {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  align-items: center;
+  padding: clamp(1.5rem, 3vw, 2rem);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 1rem;
+  box-shadow: 0 1px 2px rgba(25, 25, 22, 0.04);
+}
+
+@media (max-width: 640px) {
+  .user-detail__hero {
+    grid-template-columns: 1fr;
+    text-align: center;
+    justify-items: center;
+  }
+}
+
+.user-detail__avatar-stage {
+  width: clamp(7rem, 14vw, 10rem);
+  height: clamp(7rem, 14vw, 10rem);
+  flex-shrink: 0;
+  perspective: 800px;
+}
+
+.user-detail__avatar {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
+  background: var(--c-uniandes-color-neutro-30);
+  border: 4px solid var(--color-bg);
+  box-shadow:
+    0 0 0 1px var(--color-border),
+    0 8px 24px rgba(25, 25, 22, 0.12);
+  transform-origin: center;
+  transition: transform 160ms cubic-bezier(0.2, 0, 0, 1);
+  will-change: transform;
+}
+
+.user-detail__avatar--initials {
+  display: grid;
+  place-items: center;
+  font-size: clamp(2rem, 4.5vw, 3rem);
+  font-weight: 700;
+  color: var(--c-uniandes-color-primarytext-lightbg);
+  background: var(--c-uniandes-color-secondary-02-lightbg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .user-detail__avatar {
+    transition: none;
+    transform: none !important;
+  }
+}
+
+.user-detail__identity {
+  min-width: 0;
+}
+
+.user-detail__eyebrow {
+  margin: 0;
+}
+
+.user-detail__role {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.3125rem 0.625rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.user-detail__role--admin {
+  background: var(--c-uniandes-color-secondary-02-lightbg);
+  color: var(--c-uniandes-color-primarytext-lightbg);
+  border-color: var(--c-uniandes-color-secondary-01-lightbg);
+}
+
+.user-detail__role--developer {
+  background: var(--c-uniandes-color-neutro-30);
+  color: var(--c-uniandes-color-primarytext-lightbg);
+  border-color: var(--color-border);
+}
+
+.user-detail__role--designer {
+  background: rgba(36, 66, 178, 0.08);
+  color: var(--color-accent);
+  border-color: rgba(36, 66, 178, 0.25);
+}
+
+.user-detail__name {
+  font-size: clamp(2rem, 5vw, 3rem);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  line-height: 1.1;
+  margin: 0.5rem 0 0.25rem;
+  color: var(--color-text);
+  /* Franja amarilla Uniandes bajo el nombre — destaca como título focal
+     de la página de detalle. `width: fit-content` ajusta la franja al
+     ancho del texto en lugar de extenderla a todo el contenedor. */
+  width: fit-content;
+  max-width: 100%;
+  background-image: linear-gradient(
+    var(--c-uniandes-color-secondary-01-lightbg),
+    var(--c-uniandes-color-secondary-01-lightbg)
+  );
+  background-repeat: no-repeat;
+  background-position: 0 92%;
+  background-size: 100% 0.35em;
+}
+
+@media (max-width: 640px) {
+  .user-detail__name {
+    margin-inline: auto;
+  }
+}
+
+.user-detail__username {
+  margin: 0;
+  font-size: clamp(0.9375rem, 1.5vw, 1.0625rem);
+  color: var(--color-text-muted);
+  font-feature-settings: 'tnum' 1;
+}
+
+/* ── Meta inline ─────────────────────────────────────────────────────── */
+.user-detail__meta {
+  list-style: none;
+  padding: 0;
+  margin: var(--space-4) 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-4);
+  font-size: 0.9375rem;
+  color: var(--color-text-muted);
+}
+
+.user-detail__meta-item {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  min-width: 0;
+}
+
+.user-detail__meta-item svg {
+  width: 1rem;
+  height: 1rem;
+  color: var(--c-uniandes-color-neutro-70);
+  flex-shrink: 0;
+}
+
+.user-detail__meta-item a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  color: inherit;
+  text-decoration: none;
+  border-radius: 0.25rem;
+  transition: color 160ms ease;
+}
+
+.user-detail__meta-item a:hover {
+  color: var(--color-text);
+}
+
+.user-detail__meta-item a:hover span {
+  text-decoration: underline;
+}
+
+.user-detail__meta-item a:focus-visible {
+  outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
+  outline-offset: 2px;
+}
+
+.user-detail__meta-item--static {
+  color: var(--color-text-muted);
+}
+
+@media (max-width: 640px) {
+  .user-detail__meta {
+    justify-content: center;
+  }
+}
+
+/* ── Section blocks (repos + others) ─────────────────────────────────── */
+.user-detail__section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.user-detail__section-title {
+  font-size: clamp(1.25rem, 2vw, 1.5rem);
+  font-weight: 600;
+  margin: 0;
+  color: var(--color-text);
+}
+
+.user-detail__empty {
+  margin: 0;
+  padding: var(--space-6);
+  border: 1px dashed var(--color-border);
+  border-radius: 0.5rem;
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+  text-align: center;
+  font-size: 0.9375rem;
+}
+
+/* ── Repos grid (mismo CSS Grid uniforme que las otras páginas) ──────── */
+.user-detail__repos-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(18rem, 100%), 1fr));
+  gap: var(--space-6);
+}
+
+.user-detail__repos-item {
+  min-width: 0;
+  opacity: 0;
+  transform: translateY(8px);
+  animation: fadeUp 420ms cubic-bezier(0.2, 0, 0, 1) forwards;
+}
+
+.user-detail__repos-item:nth-child(1) {
+  animation-delay: 60ms;
+}
+.user-detail__repos-item:nth-child(2) {
+  animation-delay: 120ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .user-detail__repos-item {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* ── Rail horizontal de "otros usuarios" ─────────────────────────────── */
+.user-detail__rail-wrapper {
+  position: relative;
+}
+
+.user-detail__rail {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: var(--space-4);
+  overflow-x: auto;
+  scroll-behavior: smooth;
+  scroll-snap-type: x proximity;
+  /* Scrollbar nativa oculta — la navegación del rail se hace con las
+     flechas. Mantenemos overflow auto para conservar swipe táctil y
+     scroll-wheel horizontal. */
+  scrollbar-width: none;
+}
+
+.user-detail__rail::-webkit-scrollbar {
+  display: none;
+}
+
+/* ── Flechas de control ──────────────────────────────────────────────── */
+.user-detail__rail-arrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 2;
+  display: inline-grid;
+  place-items: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  background: var(--color-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: 50%;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(25, 25, 22, 0.1);
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease,
+    opacity 200ms ease,
+    transform 160ms ease;
+}
+
+.user-detail__rail-arrow:hover:not(:disabled) {
+  background: var(--c-uniandes-color-secondary-01-lightbg);
+  border-color: var(--c-uniandes-color-secondary-01-lightbg);
+  color: var(--c-uniandes-color-primarytext-lightbg);
+  transform: translateY(-50%) scale(1.06);
+}
+
+.user-detail__rail-arrow:focus-visible {
+  outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
+  outline-offset: 2px;
+}
+
+.user-detail__rail-arrow:disabled {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.user-detail__rail-arrow svg {
+  width: 1.125rem;
+  height: 1.125rem;
+}
+
+.user-detail__rail-arrow--prev {
+  left: -0.5rem;
+}
+
+.user-detail__rail-arrow--next {
+  right: -0.5rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .user-detail__rail {
+    scroll-behavior: auto;
+  }
+  .user-detail__rail-arrow {
+    transition: none;
+  }
+  .user-detail__rail-arrow:hover:not(:disabled) {
+    transform: translateY(-50%);
+  }
+}
+
+.user-detail__rail-item {
+  scroll-snap-align: start;
+  flex-shrink: 0;
+}
+
+.other-user {
+  display: grid;
+  grid-template-rows: auto auto auto;
+  gap: 0.375rem;
+  width: 11rem;
+  padding: var(--space-4);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 0.75rem;
+  text-decoration: none;
+  color: inherit;
+  text-align: center;
+  justify-items: center;
+  transition:
+    transform 220ms cubic-bezier(0.2, 0, 0, 1),
+    border-color 220ms cubic-bezier(0.2, 0, 0, 1),
+    box-shadow 220ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+.other-user:hover {
+  transform: translateY(-2px);
+  border-color: var(--c-uniandes-color-neutro-50);
+  box-shadow: 0 6px 18px rgba(25, 25, 22, 0.08);
+}
+
+.other-user:focus-visible {
+  outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .other-user {
+    transition: none;
+  }
+  .other-user:hover {
+    transform: none;
+  }
+}
+
+.other-user__avatar {
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 50%;
+  object-fit: cover;
+  background: var(--c-uniandes-color-neutro-30);
+  border: 2px solid var(--color-bg);
+  box-shadow: 0 0 0 1px var(--color-border);
+}
+
+.other-user__name {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.other-user__role {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.125rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.other-user__role--admin {
+  background: var(--c-uniandes-color-secondary-02-lightbg);
+  color: var(--c-uniandes-color-primarytext-lightbg);
+  border-color: var(--c-uniandes-color-secondary-01-lightbg);
+}
+
+.other-user__role--developer {
+  background: var(--c-uniandes-color-neutro-30);
+  color: var(--c-uniandes-color-primarytext-lightbg);
+  border-color: var(--color-border);
+}
+
+.other-user__role--designer {
+  background: rgba(36, 66, 178, 0.08);
+  color: var(--color-accent);
+  border-color: rgba(36, 66, 178, 0.25);
+}
+
+/* ── Skeleton del hero ───────────────────────────────────────────────── */
+.user-detail__hero--skeleton {
+  pointer-events: none;
+}
+
+.user-detail__avatar-skeleton {
+  width: clamp(7rem, 14vw, 10rem);
+  height: clamp(7rem, 14vw, 10rem);
+  border-radius: 50%;
+  background: var(--c-uniandes-color-neutro-30);
+  position: relative;
+  overflow: hidden;
+}
+
+.user-detail__skeleton-lines {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.user-detail__skeleton-line {
+  height: 1rem;
+  border-radius: 0.25rem;
+  background: var(--c-uniandes-color-neutro-30);
+  position: relative;
+  overflow: hidden;
+}
+
+.user-detail__skeleton-line--lg {
+  width: 60%;
+  height: 2rem;
+}
+.user-detail__skeleton-line--md {
+  width: 30%;
+}
+.user-detail__skeleton-line--sm {
+  width: 45%;
+  height: 0.875rem;
+}
+
+.user-detail__avatar-skeleton::after,
+.user-detail__skeleton-line::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.6) 50%,
+    transparent 100%
+  );
+  transform: translateX(-100%);
+  animation: shimmer 1.4s infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .user-detail__avatar-skeleton::after,
+  .user-detail__skeleton-line::after {
+    animation: none;
+  }
+}
+
+/* ── Not found ───────────────────────────────────────────────────────── */
+.user-detail__not-found {
+  text-align: center;
+  padding: var(--space-8) var(--space-4);
+  background: var(--color-surface);
+  border: 1px dashed var(--color-border);
+  border-radius: 0.75rem;
+}
+
+.user-detail__not-found h1 {
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  margin: 0 0 var(--space-2);
+}
+
+.user-detail__not-found p {
+  margin: 0 0 var(--space-4);
+  color: var(--color-text-muted);
+}
+
+.user-detail__cta {
+  display: inline-block;
+  padding: 0.625rem 1.25rem;
+  font-weight: 500;
+  font-size: 0.9375rem;
+  color: var(--c-content-primary-default-lightbg);
+  background: var(--c-background-primary-default-lightbg);
+  border-radius: 0.5rem;
+  text-decoration: none;
+  transition:
+    background-color 160ms ease,
+    color 160ms ease,
+    transform 160ms ease;
+}
+
+.user-detail__cta:hover {
+  background: var(--c-uniandes-color-secondary-01-lightbg);
+  color: var(--c-uniandes-color-primarytext-lightbg);
+  transform: translateY(-1px);
+}
+
+.user-detail__cta:focus-visible {
+  outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
+  outline-offset: 2px;
+}

--- a/src/app/features/users/user-detail-page.html
+++ b/src/app/features/users/user-detail-page.html
@@ -1,0 +1,224 @@
+<section class="user-detail" aria-busy="false">
+  <a routerLink="/usuarios" class="user-detail__back">
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        d="M15 18l-6-6 6-6"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+    Volver a usuarios
+  </a>
+
+  @if (isLoading()) {
+    <div class="user-detail__hero user-detail__hero--skeleton" aria-hidden="true">
+      <div class="user-detail__avatar-skeleton"></div>
+      <div class="user-detail__skeleton-lines">
+        <div class="user-detail__skeleton-line user-detail__skeleton-line--lg"></div>
+        <div class="user-detail__skeleton-line user-detail__skeleton-line--md"></div>
+        <div class="user-detail__skeleton-line user-detail__skeleton-line--sm"></div>
+      </div>
+    </div>
+  } @else if (notFound()) {
+    <div class="user-detail__not-found">
+      <h1>Usuario no encontrado</h1>
+      <p>El usuario solicitado no existe o ha sido eliminado.</p>
+      <a routerLink="/usuarios" class="user-detail__cta">Ver todos los usuarios</a>
+    </div>
+  } @else if (user(); as u) {
+    <header class="user-detail__hero">
+      <div
+        class="user-detail__avatar-stage"
+        (mousemove)="onAvatarMove($event)"
+        (mouseleave)="onAvatarLeave()"
+      >
+        @if (avatarFailed()) {
+          <div
+            class="user-detail__avatar user-detail__avatar--initials"
+            [style.transform]="
+              'rotateX(' +
+              tilt().x +
+              'deg) rotateY(' +
+              tilt().y +
+              'deg) scale(' +
+              tilt().scale +
+              ')'
+            "
+            aria-hidden="true"
+          >
+            {{ initials() }}
+          </div>
+        } @else {
+          <img
+            class="user-detail__avatar"
+            [src]="u.avatarUrl"
+            [alt]="'Avatar de ' + u.name"
+            [style.transform]="
+              'rotateX(' +
+              tilt().x +
+              'deg) rotateY(' +
+              tilt().y +
+              'deg) scale(' +
+              tilt().scale +
+              ')'
+            "
+            width="160"
+            height="160"
+            decoding="async"
+            (error)="onAvatarError()"
+          />
+        }
+      </div>
+
+      <div class="user-detail__identity">
+        <p class="user-detail__eyebrow">
+          <span
+            class="user-detail__role user-detail__role--{{ u.role }}"
+            [attr.aria-label]="'Rol: ' + roleLabel()"
+          >
+            {{ roleLabel() }}
+          </span>
+        </p>
+        <h1 class="user-detail__name">{{ u.name }}</h1>
+        <p class="user-detail__username">&#64;{{ u.username }}</p>
+
+        <ul class="user-detail__meta">
+          <li class="user-detail__meta-item">
+            <a
+              [href]="mapsUrl()"
+              target="_blank"
+              rel="noopener noreferrer"
+              [attr.aria-label]="'Ver ' + u.location + ' en Google Maps (nueva pestaña)'"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path
+                  d="M12 2a7 7 0 0 0-7 7c0 5.25 7 13 7 13s7-7.75 7-13a7 7 0 0 0-7-7zm0 9.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5z"
+                  fill="currentColor"
+                />
+              </svg>
+              <span>{{ u.location }}</span>
+            </a>
+          </li>
+          <li class="user-detail__meta-item">
+            <a [href]="'mailto:' + u.email" [title]="u.email">
+              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path
+                  d="M4 4h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2zm0 4.4V18h16V8.4l-8 5-8-5z"
+                  fill="currentColor"
+                />
+              </svg>
+              <span>{{ u.email }}</span>
+            </a>
+          </li>
+          <li class="user-detail__meta-item user-detail__meta-item--static">
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path
+                d="M7 3a2 2 0 0 0-2 2v15a1 1 0 0 0 1.5.87L12 17.6l5.5 3.27A1 1 0 0 0 19 20V5a2 2 0 0 0-2-2H7zm0 2h10v13.27l-4.5-2.68a1 1 0 0 0-1 0L7 18.27V5z"
+                fill="currentColor"
+              />
+            </svg>
+            <span>{{ reposLabel() }}</span>
+          </li>
+        </ul>
+      </div>
+    </header>
+
+    <section class="user-detail__section" aria-labelledby="user-detail-repos-title">
+      <h2 id="user-detail-repos-title" class="user-detail__section-title">
+        Repositorios mantenidos
+      </h2>
+      @if (userRepos().length === 0) {
+        <p class="user-detail__empty">
+          {{ u.name }} todavía no tiene repositorios públicos en GhQuerry.
+        </p>
+      } @else {
+        <ul class="user-detail__repos-grid">
+          @for (repo of userRepos(); track repo.id) {
+            <li class="user-detail__repos-item">
+              <app-repository-card [repository]="repo" [owner]="u" />
+            </li>
+          }
+        </ul>
+      }
+    </section>
+
+    @if (otherUsers().length > 0) {
+      <section class="user-detail__section" aria-labelledby="user-detail-others-title">
+        <h2 id="user-detail-others-title" class="user-detail__section-title">
+          Otros developers de la comunidad
+        </h2>
+        <div class="user-detail__rail-wrapper">
+          <button
+            type="button"
+            class="user-detail__rail-arrow user-detail__rail-arrow--prev"
+            (click)="scrollRailPrev()"
+            [disabled]="!canScrollPrev()"
+            aria-label="Ver developers anteriores"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path
+                d="M15 18l-6-6 6-6"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2.25"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
+          <ul
+            #railEl
+            class="user-detail__rail"
+            aria-label="Otros developers"
+            (scroll)="onRailScroll()"
+          >
+            @for (other of otherUsers(); track other.id) {
+              <li class="user-detail__rail-item">
+                <a
+                  [routerLink]="['/usuarios', other.id]"
+                  class="other-user"
+                  [attr.aria-label]="'Ver detalle de ' + other.name"
+                >
+                  <img
+                    class="other-user__avatar"
+                    [src]="other.avatarUrl"
+                    [alt]=""
+                    width="56"
+                    height="56"
+                    loading="lazy"
+                    decoding="async"
+                  />
+                  <span class="other-user__name">{{ other.name }}</span>
+                  <span class="other-user__role other-user__role--{{ other.role }}">
+                    {{ roleOf(other) }}
+                  </span>
+                </a>
+              </li>
+            }
+          </ul>
+          <button
+            type="button"
+            class="user-detail__rail-arrow user-detail__rail-arrow--next"
+            (click)="scrollRailNext()"
+            [disabled]="!canScrollNext()"
+            aria-label="Ver más developers"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path
+                d="M9 6l6 6-6 6"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2.25"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
+        </div>
+      </section>
+    }
+  }
+</section>

--- a/src/app/features/users/user-detail-page.html
+++ b/src/app/features/users/user-detail-page.html
@@ -75,12 +75,14 @@
 
       <div class="user-detail__identity">
         <p class="user-detail__eyebrow">
-          <span
+          <a
             class="user-detail__role user-detail__role--{{ u.role }}"
-            [attr.aria-label]="'Rol: ' + roleLabel()"
+            routerLink="/usuarios"
+            [queryParams]="{ role: u.role }"
+            [attr.aria-label]="'Filtrar usuarios por rol ' + roleLabel()"
           >
             {{ roleLabel() }}
-          </span>
+          </a>
         </p>
         <h1 class="user-detail__name">{{ u.name }}</h1>
         <p class="user-detail__username">&#64;{{ u.username }}</p>

--- a/src/app/features/users/user-detail-page.ts
+++ b/src/app/features/users/user-detail-page.ts
@@ -1,0 +1,185 @@
+import {
+  afterNextRender,
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  type ElementRef,
+  inject,
+  input,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { RouterLink } from '@angular/router';
+
+import { RepositoryCard } from '@shared/ui/repository-card/repository-card';
+import { Repositories } from '@features/repositories/repositories';
+import { Users } from './users';
+import type { Role, User } from './user';
+
+const ROLE_LABEL: Readonly<Record<Role, string>> = {
+  admin: 'Admin',
+  developer: 'Developer',
+  designer: 'Designer',
+};
+
+interface AvatarTilt {
+  readonly x: number;
+  readonly y: number;
+  readonly scale: number;
+}
+
+const AVATAR_REST: AvatarTilt = { x: 0, y: 0, scale: 1 };
+const AVATAR_MAX_TILT_DEG = 14;
+const AVATAR_MAX_SCALE = 1.18;
+const AVATAR_MIN_SCALE = 1.06;
+
+@Component({
+  selector: 'app-user-detail-page',
+  imports: [RouterLink, RepositoryCard],
+  templateUrl: './user-detail-page.html',
+  styleUrl: './user-detail-page.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class UserDetailPage {
+  /** Bound from the route param `:id` thanks to `withComponentInputBinding()`. */
+  readonly id = input.required<string>();
+
+  private readonly usersService = inject(Users);
+  private readonly reposService = inject(Repositories);
+
+  protected readonly avatarFailed = signal(false);
+  protected readonly tilt = signal<AvatarTilt>(AVATAR_REST);
+
+  /* ── Rail "Otros developers": control programático con flechas ─────── */
+  private readonly railEl = viewChild<ElementRef<HTMLElement>>('railEl');
+  protected readonly canScrollPrev = signal(false);
+  protected readonly canScrollNext = signal(false);
+
+  constructor() {
+    /* Inicializa el estado de las flechas tras el primer render del rail. */
+    afterNextRender(() => {
+      this.recomputeRailState();
+    });
+  }
+
+  protected onRailScroll(): void {
+    this.recomputeRailState();
+  }
+
+  protected scrollRailPrev(): void {
+    this.scrollRail(-1);
+  }
+
+  protected scrollRailNext(): void {
+    this.scrollRail(1);
+  }
+
+  private scrollRail(direction: -1 | 1): void {
+    const el = this.railEl()?.nativeElement;
+    if (!el) return;
+    /* Avanzamos ~80% del viewport del rail para mostrar contenido nuevo
+       conservando una card de contexto en el borde. */
+    const delta = el.clientWidth * 0.8 * direction;
+    el.scrollBy({ left: delta, behavior: 'smooth' });
+  }
+
+  private recomputeRailState(): void {
+    const el = this.railEl()?.nativeElement;
+    if (!el) return;
+    const max = el.scrollWidth - el.clientWidth;
+    this.canScrollPrev.set(el.scrollLeft > 0);
+    /* `-1` para tolerar redondeo subpixel. */
+    this.canScrollNext.set(max > 0 && el.scrollLeft < max - 1);
+  }
+
+  private readonly allUsers = toSignal(this.usersService.list(), { initialValue: undefined });
+  private readonly allRepos = toSignal(this.reposService.list(), { initialValue: undefined });
+
+  protected readonly isLoading = computed(
+    () => this.allUsers() === undefined || this.allRepos() === undefined,
+  );
+
+  protected readonly user = computed<User | undefined>(() => {
+    const list = this.allUsers();
+    if (!list) return undefined;
+    const numeric = Number(this.id());
+    return list.find((u) => u.id === numeric);
+  });
+
+  protected readonly notFound = computed(
+    () => this.allUsers() !== undefined && this.user() === undefined,
+  );
+
+  protected readonly userRepos = computed(() => {
+    const list = this.allRepos();
+    const u = this.user();
+    if (!list || !u) return [];
+    return list.filter((r) => u.ownsRepo(r.id));
+  });
+
+  protected readonly otherUsers = computed<readonly User[]>(() => {
+    const list = this.allUsers();
+    const u = this.user();
+    if (!list || !u) return [];
+    return list.filter((other) => other.id !== u.id);
+  });
+
+  protected readonly mapsUrl = computed(() => {
+    const u = this.user();
+    if (!u) return '#';
+    const query = encodeURIComponent(`${u.location}, Colombia`);
+    return `https://www.google.com/maps/search/?api=1&query=${query}`;
+  });
+
+  protected readonly roleLabel = computed(() => {
+    const u = this.user();
+    return u ? ROLE_LABEL[u.role] : '';
+  });
+
+  protected readonly initials = computed(() => {
+    const u = this.user();
+    if (!u) return '?';
+    const parts = u.name.trim().split(/\s+/).filter(Boolean);
+    const first = parts[0]?.[0] ?? '';
+    const last = parts.length > 1 ? (parts[parts.length - 1]?.[0] ?? '') : '';
+    return (first + last).toUpperCase() || '?';
+  });
+
+  protected readonly reposLabel = computed(() => {
+    const u = this.user();
+    if (!u) return '';
+    const n = u.repoIds.length;
+    if (n === 0) return 'Sin repositorios';
+    if (n === 1) return '1 repositorio';
+    return `${String(n)} repositorios`;
+  });
+
+  protected roleOf(other: User): string {
+    return ROLE_LABEL[other.role];
+  }
+
+  protected onAvatarError(): void {
+    this.avatarFailed.set(true);
+  }
+
+  protected onAvatarMove(event: MouseEvent): void {
+    const stage = event.currentTarget as HTMLElement;
+    const rect = stage.getBoundingClientRect();
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
+    const nx = (event.clientX - cx) / (rect.width / 2);
+    const ny = (event.clientY - cy) / (rect.height / 2);
+    const dist = Math.min(1, Math.hypot(nx, ny));
+    const scale = AVATAR_MAX_SCALE - (AVATAR_MAX_SCALE - AVATAR_MIN_SCALE) * dist;
+    this.tilt.set({
+      x: -ny * AVATAR_MAX_TILT_DEG,
+      y: nx * AVATAR_MAX_TILT_DEG,
+      scale,
+    });
+  }
+
+  protected onAvatarLeave(): void {
+    this.tilt.set(AVATAR_REST);
+  }
+}

--- a/src/app/features/users/users-page.css
+++ b/src/app/features/users/users-page.css
@@ -109,39 +109,25 @@
 
 /* ── Responsive grid ─────────────────────────────────────────────────── */
 .users-grid {
-  /* Flex con justify-content:center → las cards se centran horizontalmente
-     en cada fila aunque la última no quede llena (1 sola card también). */
+  /* CSS Grid con `auto-fill + 1fr` → todos los tracks comparten la misma
+     anchura, calculada por el grid según el viewport. Una fila parcial
+     (e.g. 2 cards en grid de 3 tracks) usa los mismos tracks que una fila
+     completa: las columnas quedan alineadas verticalmente y las cards
+     llenan el ancho disponible a cada breakpoint sin huecos a la derecha. */
   list-style: none;
   margin: 0;
   padding: 0;
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  align-content: flex-start;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(18rem, 100%), 1fr));
   gap: var(--space-8);
 }
 
 .users-grid__item {
-  /* `flex: 1 1 18rem` permite a las cards crecer y rellenar el ancho del
-     contenedor → cuando hay 3 cards en una fila, sus bordes coinciden con
-     los del toolbar. `max-width: 22rem` evita que una card sola se estire
-     demasiado en pantallas anchas. */
-  flex: 1 1 18rem;
-  max-width: 22rem;
   min-width: 0;
   /* Animación escalonada de entrada */
   opacity: 0;
   transform: translateY(8px);
   animation: fadeUp 420ms cubic-bezier(0.2, 0, 0, 1) forwards;
-}
-
-/* En viewports donde solo cabe 1 columna (≤ 608 px de contenedor), la card
-   se extiende al ancho completo para alinearse con los bordes laterales
-   del toolbar. */
-@media (max-width: 640px) {
-  .users-grid__item {
-    max-width: 100%;
-  }
 }
 
 .users-grid__item:nth-child(1) {

--- a/src/app/features/users/users-page.ts
+++ b/src/app/features/users/users-page.ts
@@ -8,6 +8,7 @@ import {
   untracked,
 } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute } from '@angular/router';
 import { debounceTime, distinctUntilChanged } from 'rxjs';
 
 import { UserCard } from '@shared/ui/user-card/user-card';
@@ -23,6 +24,8 @@ import {
 import { Users } from './users';
 import type { Role, UserFilters } from './user';
 
+const VALID_ROLES = new Set<Role>(['admin', 'developer', 'designer']);
+
 @Component({
   selector: 'app-users-page',
   imports: [UserCard, Paginator, FilterToolbar, SearchInputField, ChipsField, SelectField],
@@ -32,9 +35,19 @@ import type { Role, UserFilters } from './user';
 })
 export class UsersPage {
   private readonly usersService = inject(Users);
+  private readonly route = inject(ActivatedRoute);
 
   protected readonly title = 'Usuarios';
   protected readonly pageSize = 6;
+
+  /**
+   * Query params leídos reactivamente desde `ActivatedRoute`. Pre-aplica
+   * los filtros internos cuando se entra con `?role=:name` (desde el chip
+   * de rol de un `UserCard`).
+   */
+  private readonly queryParams = toSignal(this.route.queryParamMap, {
+    initialValue: this.route.snapshot.queryParamMap,
+  });
 
   /* ── Estado de filtros ─────────────────────────────────────────────── */
   protected readonly query = signal('');
@@ -108,6 +121,19 @@ export class UsersPage {
   protected readonly skeletonSlots = Array.from({ length: this.pageSize }, (_, i) => i);
 
   constructor() {
+    /* Cuando se entra desde otra página con `?role=:name` (chip de rol de
+       un UserCard), sincroniza el query param al filtro interno. Validamos
+       contra `VALID_ROLES` para descartar valores arbitrarios de la URL. */
+    effect(() => {
+      const params = this.queryParams();
+      const roleParam = params.get('role');
+      untracked(() => {
+        if (roleParam !== null && VALID_ROLES.has(roleParam as Role) && this.role() !== roleParam) {
+          this.role.set(roleParam as Role);
+        }
+      });
+    });
+
     /* Cualquier cambio en filtros nos devuelve a la página 1. */
     effect(() => {
       this.filters();

--- a/src/app/shared/ui/filter-toolbar/select-field.html
+++ b/src/app/shared/ui/filter-toolbar/select-field.html
@@ -1,13 +1,8 @@
 <div class="select-field__wrap">
-  <select
-    class="select-field__control"
-    [value]="value() ?? ''"
-    [attr.aria-label]="ariaLabel()"
-    (change)="onChange($event)"
-  >
-    <option value="">{{ placeholder() }}</option>
+  <select class="select-field__control" [attr.aria-label]="ariaLabel()" (change)="onChange($event)">
+    <option value="" [selected]="value() === null">{{ placeholder() }}</option>
     @for (opt of options(); track $index) {
-      <option [value]="opt.value">{{ opt.label }}</option>
+      <option [value]="opt.value" [selected]="opt.value === value()">{{ opt.label }}</option>
     }
   </select>
   <svg class="select-field__chevron" viewBox="0 0 24 24" aria-hidden="true" focusable="false">

--- a/src/app/shared/ui/repository-card/repository-card.css
+++ b/src/app/shared/ui/repository-card/repository-card.css
@@ -4,6 +4,7 @@
 }
 
 .repo-card {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
@@ -13,10 +14,45 @@
   border: 1px solid var(--color-border);
   border-radius: 0.75rem;
   box-shadow: 0 1px 2px rgba(25, 25, 22, 0.04);
+  /* La card entera es clickeable (overlay link) → cursor pointer global. */
+  cursor: pointer;
   transition:
     transform 220ms cubic-bezier(0.2, 0, 0, 1),
     box-shadow 220ms cubic-bezier(0.2, 0, 0, 1),
     border-color 220ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+/* Overlay link: cubre toda la card → click navega al detalle. Los wrappers
+   internos (header/meta/footer) tienen `pointer-events: none` para dejar
+   pasar el click; los interactivos verdaderos (badge-stage para el tilt,
+   owner-link → /usuarios/:id) re-activan `pointer-events: auto` con
+   `z-index` superior para conservar su propia interacción. */
+.repo-card__link {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  border-radius: inherit;
+}
+
+.repo-card__link:focus-visible {
+  outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
+  outline-offset: 2px;
+}
+
+.repo-card__header,
+.repo-card__meta,
+.repo-card__footer {
+  position: relative;
+  z-index: 2;
+  pointer-events: none;
+}
+
+.repo-card__owner-link,
+.repo-card__badge-stage,
+.repo-card__lang {
+  position: relative;
+  z-index: 3;
+  pointer-events: auto;
 }
 
 .repo-card:hover,
@@ -114,21 +150,56 @@
 }
 
 /* ── Language chip ───────────────────────────────────────────────────── */
-.repo-card__lang {
+.repo-card__lang,
+.repo-card__lang:visited {
   align-self: start;
   display: inline-flex;
   align-items: center;
   gap: 0.375rem;
   font-size: 0.6875rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
+  font-weight: 700;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
-  padding: 0.25rem 0.5rem;
+  padding: 0.3125rem 0.625rem 0.3125rem 0.5rem;
   border-radius: 999px;
-  background: var(--c-uniandes-color-neutro-30);
+  /* Gradiente teñido por el lenguaje (`--lang-tint` lo setea el componente
+     vía `[style.--lang-tint]="languageColor()"`). Mezclamos con `transparent`
+     a 10/22% de alpha → fondo sutil que conserva legibilidad del texto. */
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--lang-tint, var(--c-uniandes-color-neutro-50)) 10%, transparent) 0%,
+    color-mix(in srgb, var(--lang-tint, var(--c-uniandes-color-neutro-50)) 22%, transparent) 100%
+  );
   color: var(--color-text);
-  border: 1px solid var(--color-border);
+  border: 1px solid color-mix(in srgb, var(--lang-tint, var(--color-border)) 40%, transparent);
   white-space: nowrap;
+  text-decoration: none;
+  /* Anillo arranca en 0 y aparece con overshoot suave en hover. */
+  box-shadow: 0 0 0 0 transparent;
+  transition:
+    box-shadow 280ms cubic-bezier(0.34, 1.4, 0.64, 1),
+    transform 200ms cubic-bezier(0.2, 0, 0, 1),
+    border-color 200ms ease,
+    filter 200ms ease;
+}
+
+.repo-card__lang:hover,
+.repo-card__lang:focus-visible {
+  /* Halo en el color del lenguaje (35% de --lang-tint sobre transparent). */
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--lang-tint, var(--color-border)) 35%, transparent);
+  transform: translateY(-1px);
+  filter: brightness(0.97);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .repo-card__lang {
+    transition: none;
+  }
+  .repo-card__lang:hover,
+  .repo-card__lang:focus-visible {
+    transform: none;
+    filter: none;
+  }
 }
 
 .repo-card__lang-dot {
@@ -136,6 +207,9 @@
   height: 0.5rem;
   border-radius: 50%;
   display: inline-block;
+  /* El dot a opacidad completa contrasta con el bg tintado al 10–22%. */
+  background: var(--lang-tint, currentColor);
+  flex-shrink: 0;
 }
 
 /* ── Meta (owner + created) ──────────────────────────────────────────── */

--- a/src/app/shared/ui/repository-card/repository-card.css
+++ b/src/app/shared/ui/repository-card/repository-card.css
@@ -1,0 +1,288 @@
+:host {
+  display: block;
+  height: 100%;
+}
+
+.repo-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  height: 100%;
+  padding: var(--space-6);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 0.75rem;
+  box-shadow: 0 1px 2px rgba(25, 25, 22, 0.04);
+  transition:
+    transform 220ms cubic-bezier(0.2, 0, 0, 1),
+    box-shadow 220ms cubic-bezier(0.2, 0, 0, 1),
+    border-color 220ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+.repo-card:hover,
+.repo-card:focus-within {
+  transform: translateY(-2px);
+  border-color: var(--c-uniandes-color-neutro-50);
+  box-shadow: 0 6px 18px rgba(25, 25, 22, 0.08);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .repo-card,
+  .repo-card__badge {
+    transition: none;
+  }
+  .repo-card:hover,
+  .repo-card:focus-within {
+    transform: none;
+  }
+  .repo-card__badge {
+    transform: none !important;
+  }
+}
+
+/* ── Header ──────────────────────────────────────────────────────────── */
+.repo-card__header {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.repo-card__badge-stage {
+  width: 3.5rem;
+  height: 3.5rem;
+  flex-shrink: 0;
+  perspective: 600px;
+}
+
+.repo-card__badge {
+  display: grid;
+  place-items: center;
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 0.875rem;
+  color: #fff;
+  border: 2px solid var(--color-bg);
+  box-shadow: 0 0 0 1px var(--color-border);
+  transform-origin: center;
+  transition: transform 160ms cubic-bezier(0.2, 0, 0, 1);
+  will-change: transform;
+}
+
+.repo-card__badge svg {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+.repo-card__identity {
+  min-width: 0;
+}
+
+.repo-card__name {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+  color: var(--color-text);
+  width: fit-content;
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.repo-card:hover .repo-card__name,
+.repo-card:focus-within .repo-card__name {
+  background-image: linear-gradient(
+    var(--c-uniandes-color-secondary-01-lightbg),
+    var(--c-uniandes-color-secondary-01-lightbg)
+  );
+  background-repeat: no-repeat;
+  background-position: 0 88%;
+  background-size: 100% 0.35em;
+}
+
+.repo-card__description {
+  margin: 0.25rem 0 0;
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+  /* 2 líneas como máximo, ellipsis al final. */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  overflow: hidden;
+}
+
+/* ── Language chip ───────────────────────────────────────────────────── */
+.repo-card__lang {
+  align-self: start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  background: var(--c-uniandes-color-neutro-30);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  white-space: nowrap;
+}
+
+.repo-card__lang-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+/* ── Meta (owner + created) ──────────────────────────────────────────── */
+.repo-card__meta {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  font-size: 0.875rem;
+}
+
+.repo-card__meta-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.repo-card__meta-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.repo-card__meta-value {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  color: var(--color-text-muted);
+}
+
+.repo-card__meta-value > span,
+.repo-card__meta-value time {
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.repo-card__owner-avatar {
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+  background: var(--c-uniandes-color-neutro-30);
+}
+
+.repo-card__owner-avatar--initials {
+  display: grid;
+  place-items: center;
+  font-size: 0.625rem;
+  font-weight: 600;
+  color: var(--color-text);
+  background: var(--c-uniandes-color-secondary-02-lightbg);
+}
+
+.repo-card__owner-unknown {
+  font-style: italic;
+  color: var(--color-text-disabled);
+}
+
+.repo-card__icon {
+  flex-shrink: 0;
+  width: 1rem;
+  height: 1rem;
+  color: var(--c-uniandes-color-neutro-70);
+}
+
+/* ── Footer (stars badge) ────────────────────────────────────────────── */
+.repo-card__footer {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--color-border);
+}
+
+.repo-card__stars {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  padding: 0.25rem 0.625rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  transition:
+    background-color 200ms ease,
+    border-color 200ms ease,
+    color 200ms ease;
+}
+
+/* ── Tiers de popularidad (alineados con la distribución 15–140 del JSON) ─
+   low   <  40 → neutro (frío)
+   mid   40–79 → azul tenue (en crecimiento)
+   high  80–119 → verde (consolidado)
+   top   ≥ 120 → dorado/alerta (top del ranking) */
+.repo-card__stars--low {
+  background: var(--c-uniandes-color-neutro-30);
+  color: var(--color-text);
+  border-color: var(--color-border);
+}
+.repo-card__stars--low .repo-card__icon {
+  color: var(--c-uniandes-color-neutro-60);
+}
+
+.repo-card__stars--mid {
+  background: rgba(36, 66, 178, 0.08);
+  color: var(--color-accent);
+  border-color: rgba(36, 66, 178, 0.25);
+}
+.repo-card__stars--mid .repo-card__icon {
+  color: var(--color-accent);
+}
+
+.repo-card__stars--high {
+  background: rgba(11, 115, 16, 0.1);
+  color: var(--c-uniandes-color-success-lightbg);
+  border-color: rgba(11, 115, 16, 0.3);
+}
+.repo-card__stars--high .repo-card__icon {
+  color: var(--c-uniandes-color-success-lightbg);
+}
+
+.repo-card__stars--top {
+  background: var(--c-uniandes-color-secondary-02-lightbg);
+  color: var(--c-uniandes-color-primarytext-lightbg);
+  border-color: var(--c-uniandes-color-secondary-01-lightbg);
+}
+.repo-card__stars--top .repo-card__icon {
+  color: var(--c-uniandes-color-alert-lightbg);
+}
+
+/* Focus visibility */
+.repo-card a:focus-visible,
+.repo-card button:focus-visible {
+  outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
+  outline-offset: 3px;
+  border-radius: 0.25rem;
+}

--- a/src/app/shared/ui/repository-card/repository-card.css
+++ b/src/app/shared/ui/repository-card/repository-card.css
@@ -183,6 +183,37 @@
   text-overflow: ellipsis;
 }
 
+.repo-card__owner-link,
+.repo-card__owner-link:visited {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  /* Hereda el muted del meta-value para no competir con el lenguaje y las
+     estrellitas como elementos visuales primarios; el subrayado en hover
+     deja claro que es interactivo. */
+  color: inherit;
+  text-decoration: none;
+  border-radius: 0.25rem;
+  transition: color 160ms ease;
+}
+
+.repo-card__owner-link:hover,
+.repo-card__owner-link:focus-visible {
+  color: var(--color-text);
+}
+
+.repo-card__owner-link:hover .repo-card__owner-name {
+  text-decoration: underline;
+}
+
+.repo-card__owner-name {
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .repo-card__owner-avatar {
   width: 1.25rem;
   height: 1.25rem;

--- a/src/app/shared/ui/repository-card/repository-card.html
+++ b/src/app/shared/ui/repository-card/repository-card.html
@@ -1,4 +1,9 @@
 <article class="repo-card" [attr.aria-labelledby]="'repo-' + repository().id + '-name'">
+  <a
+    class="repo-card__link"
+    [routerLink]="['/repositorios', repository().id]"
+    [attr.aria-label]="'Ver detalle de ' + repository().name"
+  ></a>
   <header class="repo-card__header">
     <div
       class="repo-card__badge-stage"
@@ -27,14 +32,16 @@
       </h3>
       <p class="repo-card__description">{{ repository().description }}</p>
     </div>
-    <span class="repo-card__lang" [attr.aria-label]="'Lenguaje: ' + repository().language">
-      <span
-        class="repo-card__lang-dot"
-        [style.background-color]="languageColor()"
-        aria-hidden="true"
-      ></span>
+    <a
+      class="repo-card__lang"
+      routerLink="/repositorios"
+      [queryParams]="{ language: repository().language }"
+      [style.--lang-tint]="languageColor()"
+      [attr.aria-label]="'Filtrar repositorios por ' + repository().language"
+    >
+      <span class="repo-card__lang-dot" aria-hidden="true"></span>
       {{ repository().language }}
-    </span>
+    </a>
   </header>
 
   <dl class="repo-card__meta">

--- a/src/app/shared/ui/repository-card/repository-card.html
+++ b/src/app/shared/ui/repository-card/repository-card.html
@@ -1,0 +1,95 @@
+<article class="repo-card" [attr.aria-labelledby]="'repo-' + repository().id + '-name'">
+  <header class="repo-card__header">
+    <div
+      class="repo-card__badge-stage"
+      (mousemove)="onBadgeMove($event)"
+      (mouseleave)="onBadgeLeave()"
+    >
+      <div
+        class="repo-card__badge"
+        [style.background-color]="languageColor()"
+        [style.transform]="
+          'rotateX(' + tilt().x + 'deg) rotateY(' + tilt().y + 'deg) scale(' + tilt().scale + ')'
+        "
+        aria-hidden="true"
+      >
+        <svg viewBox="0 0 24 24" focusable="false">
+          <path
+            d="M9.4 16.6 4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0L19.2 12l-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"
+            fill="currentColor"
+          />
+        </svg>
+      </div>
+    </div>
+    <div class="repo-card__identity">
+      <h3 [id]="'repo-' + repository().id + '-name'" class="repo-card__name">
+        {{ repository().name }}
+      </h3>
+      <p class="repo-card__description">{{ repository().description }}</p>
+    </div>
+    <span class="repo-card__lang" [attr.aria-label]="'Lenguaje: ' + repository().language">
+      <span
+        class="repo-card__lang-dot"
+        [style.background-color]="languageColor()"
+        aria-hidden="true"
+      ></span>
+      {{ repository().language }}
+    </span>
+  </header>
+
+  <dl class="repo-card__meta">
+    <div class="repo-card__meta-row">
+      <dt class="repo-card__meta-label">Propietario</dt>
+      <dd class="repo-card__meta-value">
+        @if (owner(); as o) {
+          @if (avatarFailed()) {
+            <span
+              class="repo-card__owner-avatar repo-card__owner-avatar--initials"
+              aria-hidden="true"
+            >
+              {{ ownerInitials() }}
+            </span>
+          } @else {
+            <img
+              class="repo-card__owner-avatar"
+              [src]="o.avatarUrl"
+              [alt]="'Avatar de ' + o.name"
+              width="20"
+              height="20"
+              loading="lazy"
+              decoding="async"
+              (error)="onOwnerAvatarError()"
+            />
+          }
+          <span>{{ o.name }}</span>
+        } @else {
+          <span class="repo-card__owner-unknown">Propietario desconocido</span>
+        }
+      </dd>
+    </div>
+    <div class="repo-card__meta-row">
+      <dt class="repo-card__meta-label">Creado</dt>
+      <dd class="repo-card__meta-value">
+        <svg class="repo-card__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            d="M7 2a1 1 0 0 1 1 1v1h8V3a1 1 0 1 1 2 0v1h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2V3a1 1 0 0 1 1-1zm13 8H4v10h16V10zM4 8h16V6h-2v1a1 1 0 1 1-2 0V6H8v1a1 1 0 1 1-2 0V6H4v2z"
+            fill="currentColor"
+          />
+        </svg>
+        <time [attr.datetime]="repository().createdAt">{{ createdAtLabel() }}</time>
+      </dd>
+    </div>
+  </dl>
+
+  <footer class="repo-card__footer">
+    <span class="repo-card__stars repo-card__stars--{{ starsTier() }}">
+      <svg class="repo-card__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path
+          d="M12 2.5l2.95 5.97 6.59.96-4.77 4.65 1.13 6.56L12 17.55l-5.9 3.09 1.13-6.56-4.77-4.65 6.59-.96L12 2.5z"
+          fill="currentColor"
+        />
+      </svg>
+      {{ starsLabel() }}
+    </span>
+  </footer>
+</article>

--- a/src/app/shared/ui/repository-card/repository-card.html
+++ b/src/app/shared/ui/repository-card/repository-card.html
@@ -42,26 +42,32 @@
       <dt class="repo-card__meta-label">Propietario</dt>
       <dd class="repo-card__meta-value">
         @if (owner(); as o) {
-          @if (avatarFailed()) {
-            <span
-              class="repo-card__owner-avatar repo-card__owner-avatar--initials"
-              aria-hidden="true"
-            >
-              {{ ownerInitials() }}
-            </span>
-          } @else {
-            <img
-              class="repo-card__owner-avatar"
-              [src]="o.avatarUrl"
-              [alt]="'Avatar de ' + o.name"
-              width="20"
-              height="20"
-              loading="lazy"
-              decoding="async"
-              (error)="onOwnerAvatarError()"
-            />
-          }
-          <span>{{ o.name }}</span>
+          <a
+            class="repo-card__owner-link"
+            [routerLink]="['/usuarios', o.id]"
+            [attr.aria-label]="'Ver perfil de ' + o.name"
+          >
+            @if (avatarFailed()) {
+              <span
+                class="repo-card__owner-avatar repo-card__owner-avatar--initials"
+                aria-hidden="true"
+              >
+                {{ ownerInitials() }}
+              </span>
+            } @else {
+              <img
+                class="repo-card__owner-avatar"
+                [src]="o.avatarUrl"
+                [alt]=""
+                width="20"
+                height="20"
+                loading="lazy"
+                decoding="async"
+                (error)="onOwnerAvatarError()"
+              />
+            }
+            <span class="repo-card__owner-name">{{ o.name }}</span>
+          </a>
         } @else {
           <span class="repo-card__owner-unknown">Propietario desconocido</span>
         }

--- a/src/app/shared/ui/repository-card/repository-card.ts
+++ b/src/app/shared/ui/repository-card/repository-card.ts
@@ -1,0 +1,122 @@
+import { ChangeDetectionStrategy, Component, computed, input, signal } from '@angular/core';
+import type { Repository } from '@features/repositories/repository';
+import type { User } from '@features/users/user';
+
+/**
+ * Paleta canónica de colores de lenguaje (estilo GitHub linguist) usada para
+ * teñir el badge de identidad y el dot del chip.
+ */
+const LANGUAGE_COLOR: Readonly<Record<string, string>> = {
+  TypeScript: '#3178c6',
+  JavaScript: '#f1e05a',
+  Python: '#3572a5',
+  Java: '#b07219',
+  Go: '#00add8',
+  Rust: '#dea584',
+  'C#': '#178600',
+  'C++': '#f34b7d',
+  Ruby: '#701516',
+  Swift: '#f05138',
+  Kotlin: '#a97bff',
+  HTML: '#e34c26',
+  CSS: '#563d7c',
+  Shell: '#89e051',
+  YAML: '#cb171e',
+};
+
+const FALLBACK_LANGUAGE_COLOR = '#73726d';
+
+const DATE_FORMATTER = new Intl.DateTimeFormat('es-CO', {
+  day: 'numeric',
+  month: 'long',
+  year: 'numeric',
+});
+
+interface BadgeTilt {
+  readonly x: number;
+  readonly y: number;
+  readonly scale: number;
+}
+
+const BADGE_REST: BadgeTilt = { x: 0, y: 0, scale: 1 };
+const BADGE_MAX_TILT_DEG = 18;
+const BADGE_MAX_SCALE = 1.286;
+const BADGE_MIN_SCALE = 1.104;
+
+@Component({
+  selector: 'app-repository-card',
+  templateUrl: './repository-card.html',
+  styleUrl: './repository-card.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RepositoryCard {
+  readonly repository = input.required<Repository>();
+  readonly owner = input<User | null>(null);
+
+  protected readonly avatarFailed = signal(false);
+  protected readonly tilt = signal<BadgeTilt>(BADGE_REST);
+
+  protected readonly languageColor = computed(
+    () => LANGUAGE_COLOR[this.repository().language] ?? FALLBACK_LANGUAGE_COLOR,
+  );
+
+  protected readonly createdAtLabel = computed(() =>
+    DATE_FORMATTER.format(this.repository().createdAtDate),
+  );
+
+  protected readonly starsLabel = computed(() => {
+    const n = this.repository().stars;
+    if (n === 1) return '1 estrellita';
+    return `${String(n)} estrellitas`;
+  });
+
+  /**
+   * Tier de popularidad para colorear el badge de estrellas. Los umbrales
+   * están alineados con la distribución del dataset (15–140, media 66).
+   */
+  protected readonly starsTier = computed<'low' | 'mid' | 'high' | 'top'>(() => {
+    const n = this.repository().stars;
+    if (n >= 120) return 'top';
+    if (n >= 80) return 'high';
+    if (n >= 40) return 'mid';
+    return 'low';
+  });
+
+  protected readonly ownerInitials = computed(() => {
+    const o = this.owner();
+    if (!o) return '?';
+    const parts = o.name.trim().split(/\s+/).filter(Boolean);
+    const first = parts[0]?.[0] ?? '';
+    const last = parts.length > 1 ? (parts[parts.length - 1]?.[0] ?? '') : '';
+    return (first + last).toUpperCase() || '?';
+  });
+
+  protected onOwnerAvatarError(): void {
+    this.avatarFailed.set(true);
+  }
+
+  /**
+   * Tilt 3D + escala dinámica del badge de lenguaje, en paralelo al efecto
+   * del avatar de UserCard: el badge "mira" hacia donde apunta el cursor y
+   * crece más cuando el cursor pasa por el centro.
+   */
+  protected onBadgeMove(event: MouseEvent): void {
+    const stage = event.currentTarget as HTMLElement;
+    const rect = stage.getBoundingClientRect();
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
+    const nx = (event.clientX - cx) / (rect.width / 2);
+    const ny = (event.clientY - cy) / (rect.height / 2);
+    const dist = Math.min(1, Math.hypot(nx, ny));
+    const scale = BADGE_MAX_SCALE - (BADGE_MAX_SCALE - BADGE_MIN_SCALE) * dist;
+    this.tilt.set({
+      x: -ny * BADGE_MAX_TILT_DEG,
+      y: nx * BADGE_MAX_TILT_DEG,
+      scale,
+    });
+  }
+
+  protected onBadgeLeave(): void {
+    this.tilt.set(BADGE_REST);
+  }
+}

--- a/src/app/shared/ui/repository-card/repository-card.ts
+++ b/src/app/shared/ui/repository-card/repository-card.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, computed, input, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
 import type { Repository } from '@features/repositories/repository';
 import type { User } from '@features/users/user';
 
@@ -45,6 +46,7 @@ const BADGE_MIN_SCALE = 1.104;
 
 @Component({
   selector: 'app-repository-card',
+  imports: [RouterLink],
   templateUrl: './repository-card.html',
   styleUrl: './repository-card.css',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/shared/ui/user-card/user-card.css
+++ b/src/app/shared/ui/user-card/user-card.css
@@ -52,7 +52,8 @@
 .user-card__location,
 .user-card__email,
 .user-card__avatar-stage,
-.user-card__repos {
+.user-card__repos,
+.user-card__role {
   position: relative;
   z-index: 3;
   pointer-events: auto;
@@ -165,34 +166,97 @@
 }
 
 /* ── Role chip ───────────────────────────────────────────────────────── */
-.user-card__role {
+.user-card__role,
+.user-card__role:visited {
   align-self: start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
   font-size: 0.6875rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
+  font-weight: 700;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
-  padding: 0.25rem 0.5rem;
+  padding: 0.3125rem 0.625rem 0.3125rem 0.5rem;
   border-radius: 999px;
   border: 1px solid transparent;
   white-space: nowrap;
+  text-decoration: none;
+  /* `box-shadow` arranca en 0 transparente y se anima a un anillo en hover.
+     `cubic-bezier(0.34, 1.4, 0.64, 1)` da un ligero overshoot al aparecer
+     el anillo, como si "pop"-eara desde el chip. */
+  box-shadow: 0 0 0 0 transparent;
+  transition:
+    box-shadow 280ms cubic-bezier(0.34, 1.4, 0.64, 1),
+    transform 200ms cubic-bezier(0.2, 0, 0, 1),
+    border-color 200ms ease,
+    filter 200ms ease;
 }
 
-.user-card__role--admin {
-  background: var(--c-uniandes-color-secondary-02-lightbg);
+/* Glyph circular pequeño antes del label — refuerza identidad visual del rol. */
+.user-card__role::before {
+  content: '';
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.65;
+  flex-shrink: 0;
+}
+
+.user-card__role:hover,
+.user-card__role:focus-visible {
+  box-shadow: 0 0 0 4px var(--user-card-role-ring, transparent);
+  transform: translateY(-1px);
+  filter: brightness(0.97);
+}
+
+.user-card__role:hover::before,
+.user-card__role:focus-visible::before {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .user-card__role {
+    transition: none;
+  }
+  .user-card__role:hover,
+  .user-card__role:focus-visible {
+    transform: none;
+    filter: none;
+  }
+}
+
+/* ── Variantes por rol con gradiente sutil + halo de hover propio ────── */
+.user-card__role--admin,
+.user-card__role--admin:visited {
+  background: linear-gradient(
+    135deg,
+    var(--c-uniandes-color-secondary-02-lightbg) 0%,
+    #ffd840 100%
+  );
   color: var(--c-uniandes-color-primarytext-lightbg);
   border-color: var(--c-uniandes-color-secondary-01-lightbg);
+  --user-card-role-ring: rgba(255, 228, 30, 0.45);
 }
 
-.user-card__role--developer {
-  background: var(--c-uniandes-color-neutro-30);
+.user-card__role--developer,
+.user-card__role--developer:visited {
+  background: linear-gradient(
+    135deg,
+    var(--c-uniandes-color-neutro-30) 0%,
+    var(--c-uniandes-color-neutro-40) 100%
+  );
   color: var(--c-uniandes-color-primarytext-lightbg);
-  border-color: var(--color-border);
+  border-color: var(--c-uniandes-color-neutro-50);
+  --user-card-role-ring: rgba(138, 137, 132, 0.35);
 }
 
-.user-card__role--designer {
-  background: rgba(36, 66, 178, 0.08);
+.user-card__role--designer,
+.user-card__role--designer:visited {
+  background: linear-gradient(135deg, rgba(36, 66, 178, 0.08) 0%, rgba(36, 66, 178, 0.18) 100%);
   color: var(--color-accent);
-  border-color: rgba(36, 66, 178, 0.25);
+  border-color: rgba(36, 66, 178, 0.35);
+  --user-card-role-ring: rgba(36, 66, 178, 0.3);
 }
 
 /* ── Meta (location + email) ─────────────────────────────────────────── */

--- a/src/app/shared/ui/user-card/user-card.css
+++ b/src/app/shared/ui/user-card/user-card.css
@@ -4,6 +4,7 @@
 }
 
 .user-card {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
@@ -13,10 +14,48 @@
   border: 1px solid var(--color-border);
   border-radius: 0.75rem;
   box-shadow: 0 1px 2px rgba(25, 25, 22, 0.04);
+  /* La card entera es clickeable (overlay link) → cursor pointer global. */
+  cursor: pointer;
   transition:
     transform 220ms cubic-bezier(0.2, 0, 0, 1),
     box-shadow 220ms cubic-bezier(0.2, 0, 0, 1),
     border-color 220ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+/* Overlay link: cubre toda la card → click navega al detalle. Los demás
+   interactivos (avatar-stage, location, email) se elevan con z-index para
+   capturar sus propios clicks/hovers. */
+.user-card__link {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  border-radius: inherit;
+}
+
+.user-card__link:focus-visible {
+  outline: 2px solid var(--c-uniandes-color-secondary-01-lightbg);
+  outline-offset: 2px;
+}
+
+/* Los wrappers no capturan clicks → pasan al overlay link (que cubre toda
+   la card y navega al detalle). Solo los hijos realmente interactivos
+   (avatar-stage para tilt, location → Maps, email → mailto) re-activan
+   `pointer-events: auto` para conservar su propia interacción. */
+.user-card__header,
+.user-card__meta,
+.user-card__footer {
+  position: relative;
+  z-index: 2;
+  pointer-events: none;
+}
+
+.user-card__location,
+.user-card__email,
+.user-card__avatar-stage,
+.user-card__repos {
+  position: relative;
+  z-index: 3;
+  pointer-events: auto;
 }
 
 .user-card:hover,
@@ -250,7 +289,8 @@
   border-top: 1px solid var(--color-border);
 }
 
-.user-card__repos {
+.user-card__repos,
+.user-card__repos:visited {
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);
@@ -260,12 +300,31 @@
   padding: 0.25rem 0.625rem;
   border-radius: 999px;
   background: var(--c-uniandes-color-neutro-30);
+  text-decoration: none;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease;
 }
 
-.user-card__repos--empty {
+.user-card__repos:hover,
+.user-card__repos:focus-visible {
+  background: var(--c-uniandes-color-secondary-02-lightbg);
+  color: var(--c-uniandes-color-primarytext-lightbg);
+}
+
+.user-card__repos--empty,
+.user-card__repos--empty:visited {
   color: var(--color-text-muted);
   background: transparent;
   border: 1px dashed var(--color-border);
+}
+
+.user-card__repos--empty:hover,
+.user-card__repos--empty:focus-visible {
+  background: var(--c-uniandes-color-neutro-30);
+  border-color: var(--c-uniandes-color-neutro-50);
+  color: var(--color-text);
 }
 
 /* Focus visibility for any interactive child */

--- a/src/app/shared/ui/user-card/user-card.html
+++ b/src/app/shared/ui/user-card/user-card.html
@@ -1,4 +1,9 @@
 <article class="user-card" [attr.aria-labelledby]="'user-' + user().id + '-name'">
+  <a
+    class="user-card__link"
+    [routerLink]="['/usuarios', user().id]"
+    [attr.aria-label]="'Ver detalle de ' + user().name"
+  ></a>
   <header class="user-card__header">
     <div
       class="user-card__avatar-stage"
@@ -81,7 +86,13 @@
   </dl>
 
   <footer class="user-card__footer">
-    <span class="user-card__repos" [class.user-card__repos--empty]="user().repoIds.length === 0">
+    <a
+      class="user-card__repos"
+      [class.user-card__repos--empty]="user().repoIds.length === 0"
+      routerLink="/repositorios"
+      [queryParams]="{ owner: user().id }"
+      [attr.aria-label]="'Ver ' + repoLabel() + ' de ' + user().name"
+    >
       <svg class="user-card__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
         <path
           d="M7 3a2 2 0 0 0-2 2v15a1 1 0 0 0 1.5.87L12 17.6l5.5 3.27A1 1 0 0 0 19 20V5a2 2 0 0 0-2-2H7zm0 2h10v13.27l-4.5-2.68a1 1 0 0 0-1 0L7 18.27V5z"
@@ -89,6 +100,6 @@
         />
       </svg>
       {{ repoLabel() }}
-    </span>
+    </a>
   </footer>
 </article>

--- a/src/app/shared/ui/user-card/user-card.html
+++ b/src/app/shared/ui/user-card/user-card.html
@@ -40,12 +40,14 @@
       <h3 [id]="'user-' + user().id + '-name'" class="user-card__name">{{ user().name }}</h3>
       <p class="user-card__username">&#64;{{ user().username }}</p>
     </div>
-    <span
+    <a
       class="user-card__role user-card__role--{{ user().role }}"
-      [attr.aria-label]="'Rol: ' + roleLabel()"
+      routerLink="/usuarios"
+      [queryParams]="{ role: user().role }"
+      [attr.aria-label]="'Filtrar usuarios por rol ' + roleLabel()"
     >
       {{ roleLabel() }}
-    </span>
+    </a>
   </header>
 
   <dl class="user-card__meta">

--- a/src/app/shared/ui/user-card/user-card.ts
+++ b/src/app/shared/ui/user-card/user-card.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, computed, input, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
 import type { Role, User } from '@features/users/user';
 
 const ROLE_LABEL: Readonly<Record<Role, string>> = {
@@ -20,6 +21,7 @@ const AVATAR_MIN_SCALE = 1.104;
 
 @Component({
   selector: 'app-user-card',
+  imports: [RouterLink],
   templateUrl: './user-card.html',
   styleUrl: './user-card.css',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/styles.css
+++ b/src/styles.css
@@ -111,6 +111,21 @@
   box-sizing: border-box;
 }
 
+html {
+  /* Hace que el `scrollTo(0, 0)` que dispara
+     `withInMemoryScrolling({ scrollPositionRestoration: 'enabled' })` al
+     navegar entre rutas anime suavemente en vez de hacer un jump instantáneo.
+     También aplica a anclas y a cualquier scroll programático sin
+     `behavior` explícito. */
+  scroll-behavior: smooth;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
 html,
 body {
   margin: 0;


### PR DESCRIPTION
## Summary

Promueve a `main` el conjunto de features acumuladas en `develop`. Esta release marca el primer **major** del proyecto: el sitio pasa de un esqueleto con paginas placeholder a una experiencia completa de exploración con listados, detalles, navegación cruzada y polish visual.

> ⚠ **Versionado**: el último commit en develop (`ac48e04`) incluye `Release-As: 1.0.0` en el body para que release-please genere el tag **v1.0.0** al mergear este PR.

### Scope acumulado

- **Listado de Usuarios** (PR #25, ya en `main` desde `0.3.0` — incluido aquí únicamente como referencia histórica): filter toolbar reutilizable, paginación, cards con tilt 3D del avatar.
- **Listado de Repositorios** (PR #28): RepositoryCard con badge coloreado por lenguaje, badge de estrellitas con 4 tiers cromáticos, mismo toolbar reutilizado.
- **Vista de Detalle de Usuario** (PR #29): `/usuarios/:id` con hero (avatar grande, h1 con franja amarilla), repos del usuario, rail de "Otros developers" con flechas prev/next.
- **Vista de Detalle de Repositorio** (PR #30): `/repositorios/:id` con hero (badge coloreado, h1 con franja amarilla, owner clickeable, fecha y stars con tier), rails de "Otros repositorios del owner" y "Repositorios similares por lenguaje".
- **Cross-feature deep linking** (PR #30):
  - Chip de rol del UserCard / hero de detalle → `/usuarios?role=:role`.
  - Chip de lenguaje del RepositoryCard / hero de detalle → `/repositorios?language=:name`.
  - Badge "X repositorios" del UserCard → `/repositorios?owner=:id`.
  - Owner avatar+name del RepositoryCard / hero → `/usuarios/:id`.
- **Polish visual de chips** (PR #30): gradiente per-rol/per-lenguaje, glyph dot, halo en hover con `cubic-bezier(0.34, 1.4, 0.64, 1)` overshoot, dinámico via `--lang-tint` + `color-mix()` para los 15 lenguajes.
- **Smooth navigation** (PR #30): `withInMemoryScrolling({ scrollPositionRestoration: 'enabled' })` + `html { scroll-behavior: smooth }` con fallback bajo `prefers-reduced-motion: reduce`.
- **Routing y SSR**: `withComponentInputBinding()` + `getPrerenderParams` para `/usuarios/:id` y `/repositorios/:id` → el build prerenderiza **63 rutas estáticas** (3 base + 30 user details + 30 repo details), compatible con gh-pages.
- **Build**: budget de `anyComponentStyle` ajustado a 14kB/18kB para acomodar las páginas de detalle ricas en contenido.

## Test plan
- [x] CI ya valida lint/typecheck/format/tests/build sobre `develop` tras cada merge.
- [ ] `npm run build` localmente → 63 rutas prerenderizadas, sin warnings.
- [ ] `docker compose -f docker-compose.dev.yml up` → smoke test:
  - `/usuarios` listado, paginación, filtros (texto, rol, ubicación, con/sin repos).
  - Click en card → `/usuarios/:id` con hero, repos del usuario y rail de otros developers (flechas prev/next, scroll smooth).
  - Click en chip de rol → `/usuarios?role=:role` con filtro pre-aplicado.
  - Click en badge "X repositorios" → `/repositorios?owner=:id`.
  - `/repositorios` listado, paginación, filtros (texto, lenguaje, propietario, populares/emergentes).
  - Click en card → `/repositorios/:id` con hero, rails de otros repos del owner y similares por lenguaje.
  - Click en chip de lenguaje → `/repositorios?language=:name`.
  - Click en owner del hero o de una repo card → `/usuarios/:id`.
  - Hover sobre chips de rol/lenguaje → halo overshooting + lift sutil.
- [ ] Release-please debe abrir su propio PR `chore(main): release 1.0.0` tras el merge a main.

## Commits clave
- `ac48e04` — `chore: release 1.0.0` (Release-As marker)
- `250fbdc` — Merge PR #30 (detalle de repositorio + deep linking)
- `7efc73a` — Merge PR #29 (detalle de usuario)
- `f435d2a` — Merge PR #28 (listado de repositorios)